### PR TITLE
[research] Phase 0 API gap analysis

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,3 +7,16 @@ This repo is in **bootstrap phase**.
 - Read `BOOTSTRAP.md` first if this is your first session in this repo.
 - `MCP_PLAYBOOK.md` is the authoritative project-agnostic reference.
 - This file accrues contacts-specific guidance as the project grows.
+
+## Phase 0 — API decision (2026-04-29)
+
+**Primary:** `Contacts.framework` via PyObjC (`pyobjc-framework-Contacts`).
+**Fallback:** AppleScript via `osascript` for two specific cases:
+1. **`note` field** — entitlement-gated in CN, silently dropped on fetch + stripped from vCard export.
+2. **`modificationDate` / `creationDate`** — accessible only via undocumented runtime selectors in CN.
+
+JXA contributes nothing SDEF doesn't expose — out of scope.
+vCard via `CNContactVCardSerialization` is a serialization helper (3.0 only, even on macOS 26).
+
+Full empirical basis: [`docs/research/contacts-api-gap-analysis.md`](../docs/research/contacts-api-gap-analysis.md).
+Decision drives: skill name `contacts-framework` (BOOTSTRAP §4.2); paired `check_pyobjc_safety.sh` alongside `check_applescript_safety.sh` (deferred to v0.4.0); `_run_cn_*` + `_run_applescript_*` mock boundaries in `contacts_connector.py`.

--- a/docs/research/contacts-api-gap-analysis.md
+++ b/docs/research/contacts-api-gap-analysis.md
@@ -1,7 +1,7 @@
 # Contacts API Gap Analysis (Phase 0)
 
 > **Status:** authoritative as of 2026-04-29 on macOS 26.3.1.
-> Probes were run against a real Contacts database (1696 people, 8 groups, single iCloud container).
+> Probes were run against a real Contacts database (1696 people, 8 groups). Initial probes used a single iCloud container; multi-container behavior was verified after enabling a Google/CardDAV account (Gmail container, 0 contacts at probe time but fully addressable).
 > Probe scripts: `/tmp/contacts-probe/` (not committed — they're throwaway).
 
 ## Goal
@@ -67,7 +67,7 @@ Legend: ✅ supported · ⚠ supported with caveat · ❌ not supported · — n
 | Modification / creation date | ⚠ runtime selector only (undocumented) | ✅ `modification date` / `creation date` | ✅ | — |
 | Group CRUD | ✅ | ✅ | ✅ | — |
 | Group membership | ✅ `addMember:toGroup:` | ✅ `add person to group` | ✅ | — |
-| Containers | ✅ `CNContainer` | ❌ | ❌ | — |
+| Containers (multi-account) | ✅ `CNContainer`, `defaultContainerIdentifier`, `predicateForContactsInContainerWithIdentifier:` | ❌ no `account` class — unified view only | ❌ same as AS | — |
 | vCard 3.0 export | — | — | — | ✅ but **strips NOTE** |
 | vCard 3.0 import (parse) | — | — | — | ✅ |
 | vCard 4.0 export | — | — | — | ❌ outputs 3.0 even on input 4.0 |
@@ -297,7 +297,14 @@ This maps directly onto the BOOTSTRAP-defined milestones:
 5. **Photo format** — Contacts.framework returns raw bytes; magic-byte detection (JPEG/PNG/HEIC) needed in the response. Test with iCloud-synced contacts for HEIC variants. Deferred to v0.3.0.
 6. **Authorization revocation mid-process** — if the user revokes during operation, the next call returns empty results / error silently in some cases. Build a re-check at the entry of every tool, not just at start-up. Captured as a v0.4.0 hardening task.
 7. **Test mode safety pattern** — `CONTACTS_TEST_MODE=true` + `CONTACTS_TEST_GROUP=<name>`. Destructive ops verify the target group via the API before proceeding. Same pattern as `apple-mail-mcp`'s `check_test_mode_safety`. Captured for v0.1.0 implementation.
-8. **Containers and `On My Mac`** — single-container test database (iCloud only). Need a multi-container test rig (a non-iCloud Mac account) before shipping P3 container features.
+8. **Containers — multi-account behavior** — verified empirically on a 2-container rig (iCloud + Google/CardDAV; the Google container was synced but empty at probe time, which is fine for shape testing). Findings:
+   - `containers()` returns both, each with a stable UUID-shaped `identifier` and a user-visible `name` ("iCloud", "Gmail").
+   - **All accounts surface as `CNContainerTypeCardDAV` (3)** in this rig — even iCloud is CardDAV under the hood. `CNContainerTypeLocal` (1) only applies to the legacy "On My Mac" account, which is hidden by default in current macOS.
+   - `defaultContainerIdentifier` returns the iCloud UUID. New contacts created via `addContact:toContainerWithIdentifier:None` land there. To create in Gmail, pass the Gmail container's identifier explicitly.
+   - **`enumerateContacts*` is auto-unified across containers** — no extra work needed for cross-account reads. Use `predicateForContactsInContainerWithIdentifier:` to scope.
+   - Groups are owned by exactly one container (probed via `predicateForContainerOfGroupWithIdentifier:`). All 8 groups in the test rig live in iCloud; the Gmail container has none. **CardDAV groups are provider-dependent** — Google CardDAV may or may not expose groups. Worth re-probing with a populated Google Contacts.
+   - **AppleScript is container-blind**: no `account` class, `name of every account` errors with `-2741`. AppleScript fallback paths (notes, mod-dates) operate on the unified view; they identify contacts by UUID, so cross-container ambiguity isn't a problem in practice.
+   - Open empirical follow-ups: (a) write a contact into the Gmail container and verify round-trip; (b) test with a populated Google Contacts to see whether CardDAV groups surface; (c) re-probe with Exchange/On-My-Mac if either becomes available, since `CNContainerTypeExchange` (2) and `CNContainerTypeLocal` (1) are still untested.
 
 ## 7. Decision
 

--- a/docs/research/contacts-api-gap-analysis.md
+++ b/docs/research/contacts-api-gap-analysis.md
@@ -1,0 +1,315 @@
+# Contacts API Gap Analysis (Phase 0)
+
+> **Status:** authoritative as of 2026-04-29 on macOS 26.3.1.
+> Probes were run against a real Contacts database (1696 people, 8 groups, single iCloud container).
+> Probe scripts: `/tmp/contacts-probe/` (not committed — they're throwaway).
+
+## Goal
+
+Inventory every Contacts.app capability and map each to one of four API surfaces — AppleScript SDEF, Contacts.framework via PyObjC, JXA, vCard. Pick a primary API for v0.1.0+.
+
+## TL;DR — API decision
+
+**Primary: Contacts.framework via PyObjC. Fallback: AppleScript via `osascript`.**
+
+Contacts.framework is faster (≈4–5×), produces structured data without ASObjC plumbing, and supports predicate fetches. AppleScript is the **mandatory** fallback for two specific cases:
+
+1. **`note` field** — entitlement-gated in Contacts.framework (silently dropped on fetch, stripped on vCard export). Read/write via AppleScript works without entitlement.
+2. **`modificationDate` / `creationDate`** — accessible via undocumented runtime selectors in Contacts.framework, but not part of the supported `CNContactKey` set. AppleScript exposes them via the standard scripting bridge. Use AppleScript for any "what changed since X" query if Apple removes the runtime selectors in a later macOS.
+
+vCard via `CNContactVCardSerialization` is a serialization helper — emits 3.0 only (even on macOS 26), accepts 3.0 + 4.0 input. Treat it as transport, not as a primary surface.
+
+JXA exposes nothing SDEF doesn't and adds JavaScript-bridge overhead — **drop it from consideration**.
+
+## 1. Inventory of Contacts.app capabilities
+
+User-visible features in Contacts.app and macOS Contacts data:
+
+| Capability | Notes |
+|---|---|
+| Read/list contacts | 1696 in the test database |
+| Create / update / delete contact | `CNSaveRequest` add/update/delete |
+| Search by name | predicate or `whose name contains` |
+| Filter by group, by attribute (email, phone, org) | predicate-based |
+| Read/write fields: name parts (first/middle/last/suffix/maiden/phonetic), nickname, organization, department, job title | all surfaces |
+| Read/write phones, emails, postal addresses, URLs (multi-valued, labeled) | all surfaces; **labels come back as `_$!<Home>!$_` tokens** that need translation |
+| Read/write social profiles, instant messages, related names, custom dates | all surfaces |
+| **Notes** (free-text) | **entitlement-gated in CNContacts**; AppleScript only |
+| Photos (read/write image data) | both surfaces |
+| Read birthday | both surfaces |
+| Groups: create, rename, delete | both surfaces; `CNGroup` + `CNSaveRequest` |
+| Group membership: add/remove person to/from group | both surfaces; `addMember:toGroup:` on `CNSaveRequest` |
+| Containers (iCloud / On My Mac / Exchange) | `CNContainer` — Contacts.framework only |
+| vCard import/export (3.0) | `CNContactVCardSerialization` |
+| vCard 4.0 export | **not supported** — Apple emits 3.0 only |
+| Mod/creation timestamps | undocumented in CN; standard in AppleScript |
+| Smart groups / saved searches | UI only — no scripting bridge |
+| Sharing / iCloud sync state | not exposed |
+| Recents / interaction history | not exposed |
+
+## 2. Per-surface accessibility matrix
+
+Legend: ✅ supported · ⚠ supported with caveat · ❌ not supported · — not applicable
+
+| Capability | Contacts.framework (PyObjC) | AppleScript SDEF | JXA | `CNContactVCardSerialization` |
+|---|:-:|:-:|:-:|:-:|
+| **Authorization (TCC)** | ✅ explicit `CNAuthorizationStatus` | ✅ implicit (Apple Events automation) | ✅ implicit | — |
+| List/enumerate | ✅ ~0.05 s for 1696 | ✅ ~0.29 s for 1696 | ✅ same as AS | — |
+| Read by identifier (UUID) | ✅ `unifiedContactWithIdentifier:` | ✅ via `id` property | ✅ | — |
+| Predicate by name | ✅ `predicateForContactsMatchingName:` | ✅ `whose name contains` | ✅ | — |
+| Predicate by group | ✅ `predicateForContactsInGroupWithIdentifier:` | ⚠ slow loop only | ⚠ same | — |
+| Predicate by phone/email | ✅ `predicateForContactsMatchingPhoneNumber:` / `Email:` | ⚠ slow loop only | ⚠ same | — |
+| Create / update / delete | ✅ `CNSaveRequest` | ✅ `make`, set, `delete` | ✅ same as AS | — |
+| Read note | ❌ entitlement-gated (silent fail) | ✅ | ✅ | — |
+| Write note | ❌ entitlement-gated | ✅ | ✅ | — |
+| Read image data | ✅ `imageData()` + `imageDataAvailable()` | ⚠ `image of person` returns TIFF coercion (lossy) | ⚠ same as AS | — |
+| Write image data | ✅ `setImageData:` | ⚠ TIFF only | ⚠ same | — |
+| Modification / creation date | ⚠ runtime selector only (undocumented) | ✅ `modification date` / `creation date` | ✅ | — |
+| Group CRUD | ✅ | ✅ | ✅ | — |
+| Group membership | ✅ `addMember:toGroup:` | ✅ `add person to group` | ✅ | — |
+| Containers | ✅ `CNContainer` | ❌ | ❌ | — |
+| vCard 3.0 export | — | — | — | ✅ but **strips NOTE** |
+| vCard 3.0 import (parse) | — | — | — | ✅ |
+| vCard 4.0 export | — | — | — | ❌ outputs 3.0 even on input 4.0 |
+| vCard 4.0 import (parse) | — | — | — | ✅ accepts 4.0 |
+| Phone label localization | ⚠ raw `_$!<Home>!$_` token, translate via `CNLabeledValue.localizedStringForLabel:` | ⚠ same | ⚠ same | — |
+| Smart groups | ❌ | ❌ | ❌ | — |
+| Recents / interaction | ❌ | ❌ | ❌ | — |
+| Performance baseline | 53 ms / 1696 contacts | 293 ms / 1696 contacts | ~same as AS | — |
+
+## 3. TCC authorization
+
+Contacts is a TCC-protected data class on macOS. The system prompts the first time a process touches the API.
+
+### Authorization states (`CNAuthorizationStatus`)
+
+| Raw | Name | Behavior |
+|:-:|---|---|
+| 0 | `notDetermined` | Has not asked yet. Next call will prompt. |
+| 1 | `restricted` | Locked by parental controls / MDM. |
+| 2 | `denied` | User said no. Calls return empty / error. |
+| 3 | `authorized` | Full access. |
+| 4 | `limited` | macOS 14+; user granted access to a subset. |
+
+### Auth check pattern (call before any read/write)
+
+```python
+from Contacts import CNContactStore, CNEntityTypeContacts
+
+CN_STATUS = {0: "notDetermined", 1: "restricted", 2: "denied", 3: "authorized", 4: "limited"}
+
+def check_authorization() -> dict:
+    status = CNContactStore.authorizationStatusForEntityType_(CNEntityTypeContacts)
+    if status == 3 or status == 4:
+        return {"success": True, "status": CN_STATUS[status]}
+    return {
+        "success": False,
+        "error": f"Contacts access not granted (status={CN_STATUS[status]}).",
+        "error_type": "authorization_denied",
+        "remediation": "Open System Settings → Privacy & Security → Contacts and grant access.",
+    }
+```
+
+### Requesting access (will prompt)
+
+```python
+import objc
+from PyObjCTools import AppHelper
+
+store = CNContactStore.alloc().init()
+
+def on_complete(granted: bool, error: objc.objc_object | None) -> None:
+    print(f"granted={granted}, err={error}")
+
+store.requestAccessForEntityType_completionHandler_(CNEntityTypeContacts, on_complete)
+```
+
+The completion handler runs on a background queue. For a synchronous CLI flow, prefer surfacing the unauthorized state to the LLM with a clear `error_type` and let the user grant access manually, then retry.
+
+### Bundling note
+
+Running unbundled (`uv run python -m apple_contacts_mcp.server`) prompts via the launching process's TCC identity. When packaged into Claude Desktop, an `Info.plist` `NSContactsUsageDescription` key is required for the prompt copy. **This needs to be re-tested after packaging is set up; not relevant for the unbundled v0.1.0 release.**
+
+## 4. Working code samples
+
+### List contacts (Contacts.framework)
+
+```python
+from Contacts import (
+    CNContactStore,
+    CNContactFetchRequest,
+    CNContactGivenNameKey,
+    CNContactFamilyNameKey,
+    CNContactIdentifierKey,
+)
+
+store = CNContactStore.alloc().init()
+keys = [CNContactIdentifierKey, CNContactGivenNameKey, CNContactFamilyNameKey]
+req = CNContactFetchRequest.alloc().initWithKeysToFetch_(keys)
+
+contacts: list = []
+def collect(contact, stop_ptr) -> None:
+    contacts.append({
+        "id": contact.identifier(),
+        "given_name": contact.givenName(),
+        "family_name": contact.familyName(),
+    })
+
+store.enumerateContactsWithFetchRequest_error_usingBlock_(req, None, collect)
+```
+
+### Search by name (predicate)
+
+```python
+from Contacts import CNContact
+
+pred = CNContact.predicateForContactsMatchingName_("John")
+results, err = store.unifiedContactsMatchingPredicate_keysToFetch_error_(
+    pred, [CNContactIdentifierKey, CNContactGivenNameKey, CNContactFamilyNameKey], None
+)
+```
+
+### Read note (AppleScript fallback)
+
+```python
+import subprocess
+
+def read_note(contact_uuid: str) -> str:
+    script = f'''
+    tell application "Contacts"
+      set p to first person whose id is "{contact_uuid}"
+      if note of p is missing value then
+        return ""
+      else
+        return note of p
+      end if
+    end tell
+    '''
+    result = subprocess.run(
+        ["osascript", "-e", script],
+        capture_output=True, text=True, timeout=10
+    )
+    return result.stdout.strip()
+```
+
+`{contact_uuid}` MUST be sanitized (`apple_contacts_mcp.utils.escape_applescript_string` once written) — UUIDs are alphanumeric+hyphen so trivially safe, but other AppleScript-bound strings need escaping.
+
+### Group membership predicate
+
+```python
+from Contacts import CNContact
+
+groups, _ = store.groupsMatchingPredicate_error_(None, None)
+target = next((g for g in groups if g.name() == "Family"), None)
+if target:
+    pred = CNContact.predicateForContactsInGroupWithIdentifier_(target.identifier())
+    members, err = store.unifiedContactsMatchingPredicate_keysToFetch_error_(
+        pred, keys, None
+    )
+```
+
+### Create + save contact (write path — sample only, not exercised against real data)
+
+```python
+from Contacts import CNMutableContact, CNSaveRequest, CNLabeledValue, CNPhoneNumber
+
+new_contact = CNMutableContact.alloc().init()
+new_contact.setGivenName_("Jane")
+new_contact.setFamilyName_("Smith")
+phone = CNLabeledValue.labeledValueWithLabel_value_(
+    "_$!<Mobile>!$_",
+    CNPhoneNumber.phoneNumberWithStringValue_("+15550123"),
+)
+new_contact.setPhoneNumbers_([phone])
+
+save_req = CNSaveRequest.alloc().init()
+save_req.addContact_toContainerWithIdentifier_(new_contact, None)  # None = default container
+
+ok, err = store.executeSaveRequest_error_(save_req, None)
+```
+
+### vCard export (3.0 only — strips NOTE)
+
+```python
+from Contacts import CNContactVCardSerialization
+
+descriptor = CNContactVCardSerialization.descriptorForRequiredKeys()
+req = CNContactFetchRequest.alloc().initWithKeysToFetch_([descriptor])
+out: list = []
+def cb(c, sp) -> None:
+    out.append(c)
+store.enumerateContactsWithFetchRequest_error_usingBlock_(req, None, cb)
+
+data, err = CNContactVCardSerialization.dataWithContacts_error_(out, None)
+vcard_text = bytes(data).decode("utf-8")  # PRODID: -//Apple Inc.//macOS X.Y.Z//EN, VERSION:3.0
+```
+
+### vCard parse (3.0 + 4.0 input both work)
+
+```python
+v = b"""BEGIN:VCARD
+VERSION:4.0
+FN:Jane Smith
+N:Smith;Jane;;;
+TEL;TYPE=cell:+1-555-0200
+END:VCARD
+"""
+contacts, err = CNContactVCardSerialization.contactsWithData_error_(v, None)
+```
+
+## 5. Priority tiers for the v0.1.0+ roadmap
+
+| Tier | Capability | Surface |
+|---|---|---|
+| **P1** | `list_contacts` (paged) | CN |
+| **P1** | `get_contact` (by UUID) | CN |
+| **P1** | `search_contacts` (by name predicate) | CN |
+| **P1** | `create_contact` | CN + `CNSaveRequest` |
+| **P1** | `update_contact` | CN + `CNSaveRequest` |
+| **P1** | `delete_contact` | CN + `CNSaveRequest` |
+| **P1** | TCC authorization status check + clear error surfacing | CN |
+| **P2** | Notes read/write | **AppleScript fallback** |
+| **P2** | `search_contacts` (by phone, email, organization) | CN predicates |
+| **P2** | `list_groups` | CN |
+| **P2** | `get_contacts_in_group` | CN predicate |
+| **P2** | `add_contact_to_group` / `remove_contact_from_group` | CN + `CNSaveRequest` |
+| **P2** | `export_vcard` (one or many contacts) | `CNContactVCardSerialization` |
+| **P2** | `import_vcard` | `CNContactVCardSerialization` |
+| **P3** | `create_group` / `rename_group` / `delete_group` | CN + `CNSaveRequest` |
+| **P3** | Photo read/write | CN + `imageData` |
+| **P3** | Containers (multi-source: iCloud / On My Mac / Exchange) | CN `CNContainer` |
+| **P3** | Custom dates, social profiles, related names, IM | CN |
+| **P3** | Phone label localization helper (translate `_$!<Home>!$_` → "home") | CN `CNLabeledValue.localizedStringForLabel:` |
+
+This maps directly onto the BOOTSTRAP-defined milestones:
+
+- **v0.1.0** — Tier P1 (core CRUD)
+- **v0.2.0** — Tier P2 (filters/queries; group ops; vCard)
+- **v0.3.0** — Tier P3 (niche fields, photo, containers)
+- **v0.4.0** — Infrastructure hardening (coverage 90%, rate limiting, confirmation UX, test-mode safety, packaging Info.plist for Claude Desktop)
+
+## 6. Open empirical questions
+
+1. **Notes entitlement** — Apple grants `com.apple.developer.contacts.notes` on a case-by-case basis for App Store apps. We are unbundled and won't get it. Is the AppleScript fallback acceptable for v0.1.0, or do we surface a "notes feature requires AppleScript" capability flag the LLM can check? **Decision: AppleScript fallback only; document.**
+2. **`modificationDate` / `creationDate` durability** — these are not documented `CNContactKey` constants but are accessible via runtime selectors. Are they stable across macOS 26 → 27? Re-check after each macOS major release. If they break, AppleScript is the fallback.
+3. **vCard 4.0 export** — no native path. Open question whether to (a) post-process the 3.0 output to upgrade to 4.0, (b) ship a 3rd-party encoder (e.g., `vobject`), or (c) document 3.0-only as the limitation. **Decision: deferred to v0.2.0 — emit 3.0 in v0.1.0; revisit before v0.2.0.**
+4. **Phone label translation** — should the MCP layer translate `_$!<Mobile>!$_` → `"mobile"` on read? Yes for output, but **on input** we need to accept "mobile" or "Home" and translate back. Adds a small bidirectional table; deferred to v0.2.0 if the table is non-trivial.
+5. **Photo format** — Contacts.framework returns raw bytes; magic-byte detection (JPEG/PNG/HEIC) needed in the response. Test with iCloud-synced contacts for HEIC variants. Deferred to v0.3.0.
+6. **Authorization revocation mid-process** — if the user revokes during operation, the next call returns empty results / error silently in some cases. Build a re-check at the entry of every tool, not just at start-up. Captured as a v0.4.0 hardening task.
+7. **Test mode safety pattern** — `CONTACTS_TEST_MODE=true` + `CONTACTS_TEST_GROUP=<name>`. Destructive ops verify the target group via the API before proceeding. Same pattern as `apple-mail-mcp`'s `check_test_mode_safety`. Captured for v0.1.0 implementation.
+8. **Containers and `On My Mac`** — single-container test database (iCloud only). Need a multi-container test rig (a non-iCloud Mac account) before shipping P3 container features.
+
+## 7. Decision
+
+**Primary surface for v0.1.0+: Contacts.framework via PyObjC.**
+
+**Mandatory AppleScript fallback for:**
+- `note` field (read + write)
+- modification / creation date queries (after Apple-Events probe whether the runtime selectors break)
+
+**Skill name in BOOTSTRAP §4.2:** `contacts-framework` (not `applescript-contacts`). A separate small skill or section will cover the AppleScript escape patterns since the fallback path uses them.
+
+**Connector mock boundary:** wrap each PyObjC call site behind a `_run_cn_*` helper, parallel to `_run_applescript`. Both helpers get mocked at the unit test level; integration tests run against a real Contacts database.
+
+**`scripts/check_applescript_safety.sh`** — copy from `apple-mail-mcp` adapted for the smaller AppleScript surface (just notes + dates).
+A new `scripts/check_pyobjc_safety.sh` is needed: scans for unsafe patterns like passing user input into KVC keys, missing `descriptorForRequiredKeys` calls before vCard export, and missing `imageDataAvailable()` guards before `imageData()` reads. **Filed as v0.4.0 infrastructure issue.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 
 dependencies = [
     "fastmcp>=0.2.0",
+    "pyobjc-framework-Contacts>=10.3",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -47,6 +47,7 @@ version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "pyobjc-framework-contacts" },
 ]
 
 [package.optional-dependencies]
@@ -76,6 +77,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=0.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7.0" },
+    { name = "pyobjc-framework-contacts", specifier = ">=10.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
@@ -1596,6 +1598,58 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyobjc-core"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b6/d5612eb40be4fd5ef88c259339e6313f46ba67577a95d86c3470b951fce0/pyobjc_core-12.1.tar.gz", hash = "sha256:2bb3903f5387f72422145e1466b3ac3f7f0ef2e9960afa9bcd8961c5cbf8bd21", size = 1000532, upload-time = "2025-11-14T10:08:28.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/bf/3dbb1783388da54e650f8a6b88bde03c101d9ba93dfe8ab1b1873f1cd999/pyobjc_core-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:93418e79c1655f66b4352168f8c85c942707cb1d3ea13a1da3e6f6a143bacda7", size = 676748, upload-time = "2025-11-14T09:30:50.023Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/d2b290708e9da86d6e7a9a2a2022b91915cf2e712a5a82e306cb6ee99792/pyobjc_core-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c918ebca280925e7fcb14c5c43ce12dcb9574a33cccb889be7c8c17f3bcce8b6", size = 671263, upload-time = "2025-11-14T09:31:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5a/6b15e499de73050f4a2c88fff664ae154307d25dc04da8fb38998a428358/pyobjc_core-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:818bcc6723561f207e5b5453efe9703f34bc8781d11ce9b8be286bb415eb4962", size = 678335, upload-time = "2025-11-14T09:32:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d2/29e5e536adc07bc3d33dd09f3f7cf844bf7b4981820dc2a91dd810f3c782/pyobjc_core-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:01c0cf500596f03e21c23aef9b5f326b9fb1f8f118cf0d8b66749b6cf4cbb37a", size = 677370, upload-time = "2025-11-14T09:33:05.273Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/f0/4b4ed8924cd04e425f2a07269943018d43949afad1c348c3ed4d9d032787/pyobjc_core-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:177aaca84bb369a483e4961186704f64b2697708046745f8167e818d968c88fc", size = 719586, upload-time = "2025-11-14T09:33:53.302Z" },
+    { url = "https://files.pythonhosted.org/packages/25/98/9f4ed07162de69603144ff480be35cd021808faa7f730d082b92f7ebf2b5/pyobjc_core-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:844515f5d86395b979d02152576e7dee9cc679acc0b32dc626ef5bda315eaa43", size = 670164, upload-time = "2025-11-14T09:34:37.458Z" },
+    { url = "https://files.pythonhosted.org/packages/62/50/dc076965c96c7f0de25c0a32b7f8aa98133ed244deaeeacfc758783f1f30/pyobjc_core-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:453b191df1a4b80e756445b935491b974714456ae2cbae816840bd96f86db882", size = 712204, upload-time = "2025-11-14T09:35:24.148Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/aa/2b2d7ec3ac4b112a605e9bd5c5e5e4fd31d60a8a4b610ab19cc4838aa92a/pyobjc_framework_cocoa-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9b880d3bdcd102809d704b6d8e14e31611443aa892d9f60e8491e457182fdd48", size = 383825, upload-time = "2025-11-14T09:40:28.354Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/5760735c0fffc65107e648eaf7e0991f46da442ac4493501be5380e6d9d4/pyobjc_framework_cocoa-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f52228bcf38da64b77328787967d464e28b981492b33a7675585141e1b0a01e6", size = 383812, upload-time = "2025-11-14T09:40:53.169Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/ee4f27ec3920d5c6fc63c63e797c5b2cc4e20fe439217085d01ea5b63856/pyobjc_framework_cocoa-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:547c182837214b7ec4796dac5aee3aa25abc665757b75d7f44f83c994bcb0858", size = 384590, upload-time = "2025-11-14T09:41:17.336Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/31/0c2e734165abb46215797bd830c4bdcb780b699854b15f2b6240515edcc6/pyobjc_framework_cocoa-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5a3dcd491cacc2f5a197142b3c556d8aafa3963011110102a093349017705118", size = 384689, upload-time = "2025-11-14T09:41:41.478Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3b/b9f61be7b9f9b4e0a6db18b3c35c4c4d589f2d04e963e2174d38c6555a92/pyobjc_framework_cocoa-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:914b74328c22d8ca261d78c23ef2befc29776e0b85555973927b338c5734ca44", size = 388843, upload-time = "2025-11-14T09:42:05.719Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/f777cc9e775fc7dae77b569254570fe46eb842516b3e4fe383ab49eab598/pyobjc_framework_cocoa-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:03342a60fc0015bcdf9b93ac0b4f457d3938e9ef761b28df9564c91a14f0129a", size = 384932, upload-time = "2025-11-14T09:42:29.771Z" },
+    { url = "https://files.pythonhosted.org/packages/58/27/b457b7b37089cad692c8aada90119162dfb4c4a16f513b79a8b2b022b33b/pyobjc_framework_cocoa-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6ba1dc1bfa4da42d04e93d2363491275fb2e2be5c20790e561c8a9e09b8cf2cc", size = 388970, upload-time = "2025-11-14T09:42:53.964Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-contacts"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/a0/ce0542d211d4ea02f5cbcf72ee0a16b66b0d477a4ba5c32e00117703f2f0/pyobjc_framework_contacts-12.1.tar.gz", hash = "sha256:89bca3c5cf31404b714abaa1673577e1aaad6f2ef49d4141c6dbcc0643a789ad", size = 42378, upload-time = "2025-11-14T10:13:14.203Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/49/a95ea5ab95170b1e497275928e275d871ab698c4d65611fcc2a685b6bf4d/pyobjc_framework_contacts-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b570807aaead01b51c25cb425526f4ac3527eec25fa8672fd450a1b558c037", size = 12086, upload-time = "2025-11-14T09:43:01.115Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f5/5d2c03cf5219f2e35f3f908afa11868e9096aff33b29b41d63f2de3595f2/pyobjc_framework_contacts-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8ab86070895a005239256d207e18209b1a79d35335b6604db160e8375a7165e6", size = 12086, upload-time = "2025-11-14T09:43:03.225Z" },
+    { url = "https://files.pythonhosted.org/packages/32/c8/2c4638c0d06447886a34070eebb9ba57407d4dd5f0fcb7ab642568272b88/pyobjc_framework_contacts-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2e5ce33b686eb9c0a39351938a756442ea8dea88f6ae2f16bff5494a8569c687", size = 12165, upload-time = "2025-11-14T09:43:05.119Z" },
+    { url = "https://files.pythonhosted.org/packages/25/43/e322dd14c77eada5a4f327f5bc094061c90efabc774b30396d1155a69c44/pyobjc_framework_contacts-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62d985098aa86a86d23bff408aac47389680da4edc61f6acf10b2197efcbd0e0", size = 12177, upload-time = "2025-11-14T09:43:06.957Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/37/53eba15f2e31950056c63b78732b73379ddbf946c5e6681f3b2773dcf282/pyobjc_framework_contacts-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ab1d78f363dfede16bd5d951327332564bae86f68834d1e657dd18fe4dc12082", size = 12346, upload-time = "2025-11-14T09:43:08.865Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8b/3200f69b77ea85fe69caa1afea444387b5e41bf44ceff11e772954d8a0d5/pyobjc_framework_contacts-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:65576c359eb31c5a5ef95e0c6714686a94bb154a508d791885ff7c33dbc8afa3", size = 12259, upload-time = "2025-11-14T09:43:10.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/81/0da71a88273aa73841cd3669431c30be627600162ec89cd170759dbffeaf/pyobjc_framework_contacts-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1fac7feca7428047abf3f094fab678c4d0413296f34c30085119850509bc2905", size = 12410, upload-time = "2025-11-14T09:43:12.667Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #1.

Phase 0 deliverable per [BOOTSTRAP.md §2](../blob/main/BOOTSTRAP.md). Empirically maps every Contacts.app capability to one of four API surfaces — SDEF/AppleScript, Contacts.framework via PyObjC, JXA, vCard — by running probes against a real 1696-contact iCloud database on macOS 26.3.1.

**API decision: Contacts.framework primary, AppleScript fallback** for two specific cases:

1. **`note` field** — entitlement-gated in CN (silently dropped on fetch, stripped from vCard export). AppleScript reads/writes notes without entitlement.
2. **`modificationDate` / `creationDate`** — accessible only via undocumented runtime selectors in CN; standard in AppleScript.

JXA contributes nothing SDEF doesn't expose — out of scope. vCard via `CNContactVCardSerialization` is a 3.0-only serialization helper.

**Performance baseline:** CN enumerates 1696 contacts in 53 ms vs. AppleScript 293 ms (~5×). Predicate fetches by name/group/phone/email work in CN; AppleScript predicates over notes time out at 60 s.

## What changed

- `docs/research/contacts-api-gap-analysis.md` — new. Inventory, accessibility matrix, TCC flow with all 5 `CNAuthorizationStatus` states, working code samples per tier, P1/P2/P3 priority mapping onto v0.1.0–v0.3.0 milestones, 8 open empirical questions.
- `pyproject.toml` — `pyobjc-framework-Contacts>=10.3` added to dependencies.
- `.claude/CLAUDE.md` — Phase 0 decision recorded so subsequent sessions inherit the context.
- `docs/research/.gitkeep` — removed (replaced by the analysis doc).

## Test plan

- [x] All probe scripts ran successfully (live, not mocked) — see commit message.
- [x] `make check-all` passes locally (lint, mypy, smoke tests, complexity, version sync, parity).
- [x] Decision drives concrete next-step artifacts: skill name `contacts-framework`, eventual `check_pyobjc_safety.sh`, `_run_cn_*` mock boundary in `contacts_connector.py`. None of those land in this PR — they're the BOOTSTRAP §3+ scope.

## Notes for reviewers

The probe scripts (`/tmp/contacts-probe/*.py`) are intentionally **not** committed — they're throwaway research artifacts and would clutter the repo. Their findings are captured in the doc.

This is a research PR, not an implementation PR. The connector and server stubs remain at zero public methods; the parity check passes vacuously. The first feature (`list_contacts`) lands in BOOTSTRAP Step 5 with the v0.1.0 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)