### PR TITLE
infra: connector mock boundary — _run_applescript + _run_cn_request_access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,7 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 warn_no_return = true
 strict_equality = true
+
+[[tool.mypy.overrides]]
+module = "Contacts"
+ignore_missing_imports = true

--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -1,14 +1,122 @@
 """ContactsConnector: backend layer for Apple Contacts operations.
 
-Real implementation lands after Phase 0 API research selects the primary
-surface (Contacts.framework via PyObjC vs. AppleScript). See BOOTSTRAP.md
-Step 2.
+All external I/O — every `osascript` invocation and every Contacts.framework
+call — flows through helpers on this class. Unit tests mock at these helpers
+(`_run_applescript`, `_run_cn_*`); integration tests hit the real boundaries.
+
+See `docs/research/contacts-api-gap-analysis.md` §7 for the boundary spec.
 """
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import threading
+from typing import TYPE_CHECKING, Any
+
+from .exceptions import (
+    ContactsAppleScriptError,
+    ContactsAuthorizationError,
+    ContactsTimeoutError,
+)
+
+if TYPE_CHECKING:
+    from Contacts import CNContactStore  # pragma: no cover
+
+logger = logging.getLogger(__name__)
 
 
 class ContactsConnector:
     """Backend connector for Apple Contacts operations."""
 
-    def __init__(self) -> None:
-        """Initialize the connector. No-op until Phase 0 lands."""
-        pass
+    def __init__(self, timeout: float = 10.0) -> None:
+        self.timeout = timeout
+        self._store: CNContactStore | None = None
+
+    # ------------------------------------------------------------------
+    # AppleScript boundary
+    # ------------------------------------------------------------------
+
+    def _run_applescript(self, script: str) -> str:
+        """Execute an AppleScript via `osascript` and return stripped stdout.
+
+        Raises:
+            ContactsTimeoutError: subprocess exceeded `self.timeout`.
+            ContactsAppleScriptError: non-zero exit or any other failure.
+        """
+        try:
+            result = subprocess.run(
+                ["/usr/bin/osascript", "-"],
+                input=script,
+                text=True,
+                capture_output=True,
+                timeout=self.timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ContactsTimeoutError(
+                f"osascript timed out after {self.timeout}s"
+            ) from exc
+        except Exception as exc:
+            raise ContactsAppleScriptError(f"osascript failed: {exc}") from exc
+
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            logger.error("AppleScript error: %s", stderr)
+            raise ContactsAppleScriptError(stderr or "osascript exited non-zero")
+
+        return result.stdout.strip()
+
+    # ------------------------------------------------------------------
+    # Contacts.framework boundary
+    # ------------------------------------------------------------------
+
+    def _get_store(self) -> CNContactStore:
+        """Return the lazily-initialized CNContactStore singleton.
+
+        PyObjC import is deferred so unit tests that mock `_run_cn_*` never
+        trigger the import.
+        """
+        if self._store is None:
+            from Contacts import CNContactStore
+
+            self._store = CNContactStore.alloc().init()
+        return self._store
+
+    def _run_cn_request_access(self) -> bool:
+        """Request TCC access to the Contacts entity. First `_run_cn_*` helper.
+
+        Bridges CN's async completion handler to a synchronous call via a
+        `threading.Event`. The callback is invoked on a CN-internal queue.
+
+        Returns:
+            True if access granted, False if explicitly denied.
+
+        Raises:
+            ContactsAuthorizationError: TCC returned an NSError.
+            ContactsTimeoutError: completion handler did not fire within
+                `self.timeout`.
+        """
+        from Contacts import CNEntityTypeContacts
+
+        store = self._get_store()
+        done = threading.Event()
+        result: dict[str, Any] = {"granted": False, "error": None}
+
+        def _callback(granted: bool, error: object | None) -> None:
+            result["granted"] = bool(granted)
+            result["error"] = error
+            done.set()
+
+        store.requestAccessForEntityType_completionHandler_(
+            CNEntityTypeContacts, _callback
+        )
+
+        if not done.wait(timeout=self.timeout):
+            raise ContactsTimeoutError(
+                f"CNContactStore.requestAccess did not complete within {self.timeout}s"
+            )
+
+        if result["error"] is not None:
+            raise ContactsAuthorizationError(str(result["error"]))
+
+        return bool(result["granted"])

--- a/src/apple_contacts_mcp/exceptions.py
+++ b/src/apple_contacts_mcp/exceptions.py
@@ -11,3 +11,15 @@ class ContactsAuthorizationError(ContactsError):
     """TCC authorization not granted for the Contacts data class."""
 
     pass
+
+
+class ContactsAppleScriptError(ContactsError):
+    """`osascript` exited non-zero or emitted a parse/runtime error."""
+
+    pass
+
+
+class ContactsTimeoutError(ContactsError):
+    """A subprocess or CN async operation exceeded its timeout."""
+
+    pass

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -1,0 +1,195 @@
+"""Unit tests for ContactsConnector mock boundary.
+
+These tests mock at the `_run_applescript` and `_run_cn_*` boundaries — never
+import PyObjC, never invoke `osascript`. Integration coverage of the real
+boundaries lands in tests/integration/ (issue #15).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apple_contacts_mcp.contacts_connector import ContactsConnector
+from apple_contacts_mcp.exceptions import (
+    ContactsAppleScriptError,
+    ContactsAuthorizationError,
+    ContactsError,
+    ContactsTimeoutError,
+)
+
+
+def test_new_exception_hierarchy() -> None:
+    assert issubclass(ContactsAppleScriptError, ContactsError)
+    assert issubclass(ContactsTimeoutError, ContactsError)
+
+
+# ---------------------------------------------------------------------------
+# _run_applescript
+# ---------------------------------------------------------------------------
+
+
+def test_run_applescript_returns_stripped_stdout() -> None:
+    connector = ContactsConnector()
+    fake_result = subprocess.CompletedProcess(
+        args=["/usr/bin/osascript", "-"],
+        returncode=0,
+        stdout="hello\n",
+        stderr="",
+    )
+    with patch("subprocess.run", return_value=fake_result) as mock_run:
+        out = connector._run_applescript('return "hello"')
+    assert out == "hello"
+    args, kwargs = mock_run.call_args
+    assert args[0] == ["/usr/bin/osascript", "-"]
+    assert kwargs["input"] == 'return "hello"'
+    assert kwargs["text"] is True
+    assert kwargs["capture_output"] is True
+    assert kwargs["timeout"] == connector.timeout
+
+
+def test_run_applescript_nonzero_exit_raises_applescript_error() -> None:
+    connector = ContactsConnector()
+    fake_result = subprocess.CompletedProcess(
+        args=["/usr/bin/osascript", "-"],
+        returncode=1,
+        stdout="",
+        stderr="syntax error: bad thing",
+    )
+    with patch("subprocess.run", return_value=fake_result):
+        with pytest.raises(ContactsAppleScriptError) as exc_info:
+            connector._run_applescript("garbage")
+    assert "syntax error: bad thing" in str(exc_info.value)
+
+
+def test_run_applescript_timeout_raises_timeout_error() -> None:
+    connector = ContactsConnector(timeout=0.5)
+
+    def boom(*_args: Any, **_kwargs: Any) -> None:
+        raise subprocess.TimeoutExpired(cmd=["/usr/bin/osascript", "-"], timeout=0.5)
+
+    with patch("subprocess.run", side_effect=boom):
+        with pytest.raises(ContactsTimeoutError) as exc_info:
+            connector._run_applescript("delay 99")
+    assert "0.5" in str(exc_info.value)
+
+
+def test_run_applescript_uses_default_timeout_of_10s() -> None:
+    connector = ContactsConnector()
+    assert connector.timeout == 10.0
+
+
+# ---------------------------------------------------------------------------
+# _get_store
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_contacts_module(
+    monkeypatch: pytest.MonkeyPatch, store_factory: MagicMock | None = None
+) -> tuple[MagicMock, types.ModuleType]:
+    """Install a fake `Contacts` module and return (CNContactStore_mock, module)."""
+    fake_module = types.ModuleType("Contacts")
+    cn_store_class = MagicMock(name="CNContactStore")
+    if store_factory is not None:
+        cn_store_class.alloc.return_value.init.return_value = store_factory
+    fake_module.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+    fake_module.CNEntityTypeContacts = 0  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "Contacts", fake_module)
+    return cn_store_class, fake_module
+
+
+def test_get_store_caches_single_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_store = MagicMock(name="store_instance")
+    cn_store_class, _ = _install_fake_contacts_module(monkeypatch, store_factory=fake_store)
+    connector = ContactsConnector()
+    first = connector._get_store()
+    second = connector._get_store()
+    assert first is second is fake_store
+    assert cn_store_class.alloc.return_value.init.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_request_access
+# ---------------------------------------------------------------------------
+
+
+def _make_store_with_immediate_callback(
+    granted: bool, error: object | None
+) -> MagicMock:
+    """A fake store whose requestAccess... invokes its callback synchronously."""
+    store = MagicMock(name="store_instance")
+
+    def request_access(_entity_type: int, callback: Any) -> None:
+        callback(granted, error)
+
+    store.requestAccessForEntityType_completionHandler_.side_effect = request_access
+    return store
+
+
+def test_run_cn_request_access_returns_true_when_granted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _make_store_with_immediate_callback(granted=True, error=None)
+    _install_fake_contacts_module(monkeypatch, store_factory=store)
+    connector = ContactsConnector()
+    assert connector._run_cn_request_access() is True
+    store.requestAccessForEntityType_completionHandler_.assert_called_once()
+
+
+def test_run_cn_request_access_returns_false_when_denied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _make_store_with_immediate_callback(granted=False, error=None)
+    _install_fake_contacts_module(monkeypatch, store_factory=store)
+    connector = ContactsConnector()
+    assert connector._run_cn_request_access() is False
+
+
+def test_run_cn_request_access_raises_when_error_returned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_error = MagicMock(name="NSError")
+    fake_error.__str__.return_value = "TCC denied"
+    store = _make_store_with_immediate_callback(granted=False, error=fake_error)
+    _install_fake_contacts_module(monkeypatch, store_factory=store)
+    connector = ContactsConnector()
+    with pytest.raises(ContactsAuthorizationError) as exc_info:
+        connector._run_cn_request_access()
+    assert "TCC denied" in str(exc_info.value)
+
+
+def test_run_cn_request_access_times_out_when_callback_never_fires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = MagicMock(name="store_instance")
+
+    def never_call(*_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    store.requestAccessForEntityType_completionHandler_.side_effect = never_call
+    _install_fake_contacts_module(monkeypatch, store_factory=store)
+    connector = ContactsConnector(timeout=0.05)
+    with pytest.raises(ContactsTimeoutError):
+        connector._run_cn_request_access()
+
+
+def test_run_cn_request_access_callback_from_other_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CN completion handler runs on a background thread in real life;
+    confirm the threading.Event bridge handles that correctly."""
+    store = MagicMock(name="store_instance")
+
+    def request_access_async(_entity_type: int, callback: Any) -> None:
+        threading.Thread(target=callback, args=(True, None), daemon=True).start()
+
+    store.requestAccessForEntityType_completionHandler_.side_effect = request_access_async
+    _install_fake_contacts_module(monkeypatch, store_factory=store)
+    connector = ContactsConnector(timeout=2.0)
+    assert connector._run_cn_request_access() is True


### PR DESCRIPTION
Closes #5.

## Summary

- Adds `_run_applescript(script)` — singular generic subprocess wrapper. All `osascript` traffic goes through here; raises `ContactsTimeoutError` / `ContactsAppleScriptError`.
- Adds `_run_cn_request_access()` — first concrete `_run_cn_*` family member. Wraps the async TCC `requestAccessForEntityType:completionHandler:` and bridges to sync via `threading.Event`.
- Adds lazy `_get_store()` so PyObjC is never imported at module load — unit tests don't need PyObjC at all.
- New exceptions: `ContactsAppleScriptError`, `ContactsTimeoutError` (both extend `ContactsError`).
- One-line mypy override for the un-stubbed `Contacts` module so this doesn't recur in every feature PR.

Pattern source: gap analysis §7 ("Connector mock boundary") + reference impl in [`apple-mail-mcp/mail_connector.py:167`](https://github.com/s-morgan-jeffries/apple-mail-mcp/blob/main/src/apple_mail_mcp/mail_connector.py#L167).

## Out of scope (deferred)

- Concrete `_run_cn_fetch_*`, `_run_cn_save_*` helpers — land with feature PRs #10–#14.
- AppleScript helpers for `note` / `modificationDate` — land with the feature PRs that need them.
- `@mcp.tool() check_authorization` — issue #9 (will be a thin server.py wrapper around `_run_cn_request_access`).
- `CONTACTS_TEST_MODE` write-protection — issue #6.

## Test plan

- [x] `make test` — 17 unit tests pass (11 new), no PyObjC needed
- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy strict clean
- [x] `make coverage` — 93.85% (gate 90%)
- [x] `make check-all` — full gate green (complexity, version sync, client/server parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)