### PR TITLE
infra: test-mode safety gate — CONTACTS_TEST_MODE + CONTACTS_TEST_GROUP

### DIFF
--- a/src/apple_contacts_mcp/security.py
+++ b/src/apple_contacts_mcp/security.py
@@ -1,9 +1,20 @@
-"""Security primitives: input sanitization, rate limiting, audit, confirmation.
+"""Security primitives: input sanitization, test-mode safety gate.
 
-Stubs for the bootstrap phase. Real implementations land alongside the first
-features. See MCP_PLAYBOOK.md §4 for the canonical security checklist and
-apple-mail-mcp/src/apple_mail_mcp/security.py for the reference implementation.
+Reference: `apple-mail-mcp/src/apple_mail_mcp/security.py`. The contacts gate
+is simpler — only one axis (the test group) — and never imports PyObjC; it
+resolves the test group's identifier via `osascript` so it can run anywhere
+the rest of the package can.
 """
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from functools import lru_cache
+from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 def sanitize_input(value: str) -> str:
@@ -13,3 +24,137 @@ def sanitize_input(value: str) -> str:
     follow the playbook's two-step pattern (sanitize_input then escape).
     """
     return value
+
+
+# ---------------------------------------------------------------------------
+# Test-mode safety gate
+# ---------------------------------------------------------------------------
+
+DESTRUCTIVE_OPERATIONS: frozenset[str] = frozenset(
+    {
+        "create_contact",
+        "update_contact",
+        "delete_contact",
+    }
+)
+"""Operations gated by `check_test_mode_safety`.
+
+Every new destructive op (group CRUD, group membership, etc.) MUST be added
+here as part of its feature PR. Ops not in this set are fail-open — the gate
+returns None for them.
+"""
+
+
+def check_test_mode_safety(
+    operation: str, group: str | None = None
+) -> dict[str, Any] | None:
+    """Enforce test-mode safety. Returns None if allowed, error dict if blocked.
+
+    In test mode (`CONTACTS_TEST_MODE=true`), destructive operations must
+    target a group whose name or CN identifier matches `CONTACTS_TEST_GROUP`.
+
+    Args:
+        operation: The operation name (e.g., "create_contact"). Must match
+            an entry in `DESTRUCTIVE_OPERATIONS` to be gated.
+        group: The group the caller asserts they are operating against
+            (name or CN identifier). Required for destructive ops in test
+            mode.
+
+    Returns:
+        None if the operation is allowed; otherwise a dict shaped
+        `{"success": False, "error": <message>, "error_type": "safety_violation"}`.
+    """
+    if not _is_test_mode_enabled():
+        return None
+
+    if operation not in DESTRUCTIVE_OPERATIONS:
+        return None
+
+    test_group = _get_test_group()
+    if test_group is None:
+        return _safety_error(
+            operation, "CONTACTS_TEST_MODE is set but CONTACTS_TEST_GROUP is not"
+        )
+
+    if group is None:
+        return _safety_error(
+            operation,
+            f"Test mode: {operation} requires explicit target group "
+            f"matching CONTACTS_TEST_GROUP={test_group!r}",
+        )
+
+    if group not in _get_test_group_identifiers(test_group):
+        return _safety_error(
+            operation,
+            f"Test mode: group {group!r} does not match "
+            f"CONTACTS_TEST_GROUP={test_group!r}",
+        )
+
+    return None
+
+
+def _is_test_mode_enabled() -> bool:
+    return os.environ.get("CONTACTS_TEST_MODE", "").lower() == "true"
+
+
+def _get_test_group() -> str | None:
+    return os.environ.get("CONTACTS_TEST_GROUP")
+
+
+@lru_cache(maxsize=4)
+def _get_test_group_identifiers(test_group_name: str) -> frozenset[str]:
+    """Return {name, CN identifier} for the configured test group.
+
+    Resolves via `osascript` — the gate stays independent of the connector
+    and free of PyObjC. Cached per process; tests must call
+    `_get_test_group_identifiers.cache_clear()` between cases.
+
+    On lookup failure (group missing, osascript timeout, permission denied),
+    falls back to name-only matching with a warning. Degraded mode still
+    enforces the test-group boundary by name.
+    """
+    identifiers: set[str] = {test_group_name}
+    try:
+        result = subprocess.run(
+            [
+                "/usr/bin/osascript",
+                "-e",
+                f'tell application "Contacts" to return id of group "{test_group_name}"',
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.warning(
+            "Test-mode safety gate: failed to resolve id for group %r (%s); "
+            "falling back to name-only matching",
+            test_group_name,
+            exc,
+        )
+        return frozenset(identifiers)
+
+    if result.returncode == 0:
+        cn_id = result.stdout.strip()
+        if cn_id:
+            identifiers.add(cn_id)
+    else:
+        logger.warning(
+            "Test-mode safety gate: failed to resolve id for group %r (exit %d): "
+            "%s; falling back to name-only matching",
+            test_group_name,
+            result.returncode,
+            (result.stderr or "").strip(),
+        )
+    return frozenset(identifiers)
+
+
+def _safety_error(operation: str, message: str) -> dict[str, Any]:
+    """Build the standard safety-violation error dict."""
+    logger.warning("Safety violation in %s: %s", operation, message)
+    return {
+        "success": False,
+        "error": message,
+        "error_type": "safety_violation",
+    }

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,0 +1,209 @@
+"""Unit tests for the test-mode safety gate (issue #6).
+
+Mirrors `apple-mail-mcp/tests/unit/test_security.py::TestCheckTestModeSafety`
+adapted for the simpler contacts pattern (single gating axis: the test group).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from apple_contacts_mcp.security import (
+    DESTRUCTIVE_OPERATIONS,
+    _get_test_group_identifiers,
+    check_test_mode_safety,
+)
+
+
+class TestCheckTestModeSafety:
+    def setup_method(self) -> None:
+        # Resolver is process-cached; each test must start with a clean slate.
+        _get_test_group_identifiers.cache_clear()
+
+    # ------------------------------------------------------------------
+    # Test mode disabled
+    # ------------------------------------------------------------------
+
+    def test_no_test_mode_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        assert check_test_mode_safety("create_contact", group="Anything") is None
+        assert check_test_mode_safety("delete_contact") is None
+
+    def test_test_mode_explicit_false_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "false")
+        assert check_test_mode_safety("create_contact", group="Anything") is None
+
+    def test_test_mode_value_is_case_insensitive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "TRUE")
+        monkeypatch.delenv("CONTACTS_TEST_GROUP", raising=False)
+        result = check_test_mode_safety("create_contact")
+        assert result is not None  # gate is engaged
+
+    # ------------------------------------------------------------------
+    # Non-destructive operations are not gated
+    # ------------------------------------------------------------------
+
+    def test_non_destructive_op_returns_none_even_in_test_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        # No CONTACTS_TEST_GROUP set, but list_contacts is not destructive.
+        monkeypatch.delenv("CONTACTS_TEST_GROUP", raising=False)
+        assert check_test_mode_safety("list_contacts") is None
+        assert check_test_mode_safety("search_contacts", group="Anything") is None
+
+    # ------------------------------------------------------------------
+    # Destructive ops without proper config are blocked
+    # ------------------------------------------------------------------
+
+    def test_destructive_op_without_test_group_env_blocked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.delenv("CONTACTS_TEST_GROUP", raising=False)
+        result = check_test_mode_safety("create_contact", group="MCP-Test")
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+        assert "CONTACTS_TEST_GROUP" in result["error"]
+
+    def test_destructive_op_without_group_arg_blocked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        with patch("subprocess.run", side_effect=_subprocess_failure()):
+            result = check_test_mode_safety("create_contact")
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+        assert "create_contact" in result["error"]
+        assert "MCP-Test" in result["error"]
+
+    def test_group_mismatch_returns_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        with patch("subprocess.run", side_effect=_subprocess_failure()):
+            result = check_test_mode_safety("delete_contact", group="OtherGroup")
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+        assert "OtherGroup" in result["error"]
+        assert "MCP-Test" in result["error"]
+
+    # ------------------------------------------------------------------
+    # Allowed paths
+    # ------------------------------------------------------------------
+
+    def test_group_name_matches_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        with patch("subprocess.run", side_effect=_subprocess_failure()):
+            assert check_test_mode_safety("create_contact", group="MCP-Test") is None
+
+    def test_group_id_matches_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        cn_id = "ABCD1234-AAAA-BBBB-CCCC-DEADBEEF0001:ABGroup"
+        ok = subprocess.CompletedProcess(args=[], returncode=0, stdout=cn_id + "\n", stderr="")
+        with patch("subprocess.run", return_value=ok):
+            assert check_test_mode_safety("update_contact", group=cn_id) is None
+
+    # ------------------------------------------------------------------
+    # Resolver fallback behavior
+    # ------------------------------------------------------------------
+
+    def test_resolver_failure_falls_back_to_name_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        bad = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="Can't get group"
+        )
+        with patch("subprocess.run", return_value=bad):
+            # Name still matches in degraded mode.
+            assert check_test_mode_safety("create_contact", group="MCP-Test") is None
+            # But an arbitrary id does not.
+            result = check_test_mode_safety(
+                "create_contact", group="some-unresolved-id"
+            )
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+
+    def test_resolver_timeout_falls_back_to_name_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+
+        def boom(*_args: Any, **_kwargs: Any) -> None:
+            raise subprocess.TimeoutExpired(cmd=["osascript"], timeout=5)
+
+        with patch("subprocess.run", side_effect=boom):
+            assert check_test_mode_safety("create_contact", group="MCP-Test") is None
+
+    def test_resolver_caches_per_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="ID-1\n", stderr="")
+        with patch("subprocess.run", return_value=ok) as mock_run:
+            check_test_mode_safety("create_contact", group="MCP-Test")
+            check_test_mode_safety("delete_contact", group="MCP-Test")
+            check_test_mode_safety("update_contact", group="ID-1")
+        assert mock_run.call_count == 1  # cached after first lookup
+
+    # ------------------------------------------------------------------
+    # Coverage of every gated op
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("op", sorted(DESTRUCTIVE_OPERATIONS))
+    def test_each_destructive_op_is_gated(
+        self, op: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.delenv("CONTACTS_TEST_GROUP", raising=False)
+        result = check_test_mode_safety(op, group="anything")
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+
+    # ------------------------------------------------------------------
+    # Error shape
+    # ------------------------------------------------------------------
+
+    def test_safety_error_shape_is_stable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.delenv("CONTACTS_TEST_GROUP", raising=False)
+        result = check_test_mode_safety("create_contact")
+        assert result is not None
+        assert set(result.keys()) == {"success", "error", "error_type"}
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        assert isinstance(result["error"], str) and result["error"]
+
+
+def _subprocess_failure() -> Any:
+    """Side effect: subprocess.run raises FileNotFoundError (no osascript).
+
+    Forces _get_test_group_identifiers to take the fallback path so tests that
+    aren't specifically about resolver behavior don't depend on a happy-path
+    mock.
+    """
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise FileNotFoundError("osascript not available in test env")
+
+    return _boom


### PR DESCRIPTION
Closes #6.

## Summary

- `check_test_mode_safety(operation, group=None)` in [security.py](src/apple_contacts_mcp/security.py) — returns `None` if allowed, structured error dict if blocked. Mirrors [apple-mail-mcp pattern](https://github.com/s-morgan-jeffries/apple-mail-mcp/blob/main/src/apple_mail_mcp/security.py#L370).
- `DESTRUCTIVE_OPERATIONS = {"create_contact", "update_contact", "delete_contact"}` — explicit enumeration; future destructive ops extend it as they ship.
- Test-group identifier resolved via `osascript` (gate stays independent of the connector and free of PyObjC). `@lru_cache(maxsize=4)`. Name-only fallback on lookup failure (degraded, not fatal).
- 16 unit tests; `security.py` at 100% coverage, project total 96.30%.

## Behavior

| Scenario | Result |
|---|---|
| `CONTACTS_TEST_MODE` unset / not `"true"` | All ops pass (`None`) |
| Test mode on, op not destructive | Pass (`None`) |
| Test mode on, destructive op, no `CONTACTS_TEST_GROUP` | Block — error mentions the missing env var |
| Test mode on, destructive op, no `group` arg | Block — error tells caller to pass `CONTACTS_TEST_GROUP` |
| Test mode on, destructive op, `group` matches by name or CN id | Pass (`None`) |
| Test mode on, destructive op, `group` mismatch | Block — error names both the bad group and the test group |

## Out of scope (deferred)

- Wiring the gate into actual `@mcp.tool()` call sites — happens in #13 (`create_contact`) and #14 (`update_contact`/`delete_contact`).
- Audit-log integration in `_safety_error` — separate v0.4.0 issue per playbook §4.
- Container alignment check (gap-analysis §6 Q8) — lands with group-membership feature PR.
- Group-CRUD ops in `DESTRUCTIVE_OPERATIONS` — v0.2.0+; their PRs extend the set.

## Test plan

- [x] `make test` — 33 tests (16 new), all pass
- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy strict clean
- [x] `make coverage` — 96.30% (gate 90%); `security.py` at 100%
- [x] `make check-all` — full gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)