### PR TITLE
feat: check_authorization tool — surface TCC status to the LLM

### DIFF
--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -25,6 +25,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_CN_AUTHORIZATION_STATUS: dict[int, str] = {
+    0: "notDetermined",
+    1: "restricted",
+    2: "denied",
+    3: "authorized",
+    4: "limited",  # macOS 14+
+}
+
 
 class ContactsConnector:
     """Backend connector for Apple Contacts operations."""
@@ -81,6 +89,24 @@ class ContactsConnector:
 
             self._store = CNContactStore.alloc().init()
         return self._store
+
+    def _run_cn_authorization_status(self) -> str:
+        """Return the current TCC status string for the Contacts entity.
+
+        Wraps the synchronous class method
+        +[CNContactStore authorizationStatusForEntityType:]. No permission
+        is required to call this; it's a status getter.
+        """
+        from Contacts import CNContactStore, CNEntityTypeContacts
+
+        raw = int(
+            CNContactStore.authorizationStatusForEntityType_(CNEntityTypeContacts)
+        )
+        status = _CN_AUTHORIZATION_STATUS.get(raw)
+        if status is None:
+            logger.warning("Unknown CN authorization status: %d", raw)
+            return "notDetermined"
+        return status
 
     def _run_cn_request_access(self) -> bool:
         """Request TCC access to the Contacts entity. First `_run_cn_*` helper.

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -1,6 +1,9 @@
 """FastMCP server for Apple Contacts integration."""
 
+from __future__ import annotations
+
 import logging
+from typing import Any
 
 from fastmcp import FastMCP
 
@@ -14,6 +17,61 @@ logger = logging.getLogger(__name__)
 
 mcp: FastMCP = FastMCP("apple-contacts")
 connector = ContactsConnector()
+
+
+_AUTH_REMEDIATION: dict[str, str] = {
+    "notDetermined": (
+        "Contacts access has not been requested yet. Run a data tool "
+        "(e.g. list_contacts) to trigger the system permission prompt, "
+        "or grant access manually in System Settings → Privacy & Security "
+        "→ Contacts."
+    ),
+    "denied": (
+        "Contacts access was denied. Open System Settings → Privacy & "
+        "Security → Contacts and enable access for this server "
+        "(macOS will not re-prompt automatically)."
+    ),
+    "restricted": (
+        "Contacts access is locked by parental controls or device "
+        "management. Contact your administrator."
+    ),
+}
+
+
+@mcp.tool()
+def check_authorization() -> dict[str, Any]:
+    """Report current TCC authorization status for Contacts access.
+
+    Use this proactively before other tools, and again after any tool
+    returns error_type='authorization_denied'. Does not trigger the
+    system permission prompt; call list_contacts (or any data tool)
+    to do that.
+
+    Returns:
+        Always success: True. The status field is one of:
+          - "authorized": full access (proceed with any tool)
+          - "limited":    macOS 14+ partial access (proceed; some
+                          contacts may be hidden)
+          - "notDetermined": permission not yet requested
+          - "denied":     user explicitly denied
+          - "restricted": locked by MDM / parental controls
+        When status is not authorized/limited, the response also
+        includes a remediation field with copy you can show the user.
+    """
+    try:
+        status = connector._run_cn_authorization_status()
+    except Exception as exc:
+        logger.error("check_authorization failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"Failed to read TCC status: {exc}",
+            "error_type": "unknown",
+        }
+
+    response: dict[str, Any] = {"success": True, "status": status}
+    if status not in ("authorized", "limited"):
+        response["remediation"] = _AUTH_REMEDIATION[status]
+    return response
 
 
 def main() -> None:

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -193,3 +193,51 @@ def test_run_cn_request_access_callback_from_other_thread(
     _install_fake_contacts_module(monkeypatch, store_factory=store)
     connector = ContactsConnector(timeout=2.0)
     assert connector._run_cn_request_access() is True
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_authorization_status
+# ---------------------------------------------------------------------------
+
+
+def _install_contacts_with_status(
+    monkeypatch: pytest.MonkeyPatch, raw_status: int
+) -> MagicMock:
+    """Install a fake `Contacts` module whose CNContactStore.authorizationStatusForEntityType_
+    returns the given int. Returns the CNContactStore mock for assertions."""
+    fake_module = types.ModuleType("Contacts")
+    cn_store_class = MagicMock(name="CNContactStore")
+    cn_store_class.authorizationStatusForEntityType_.return_value = raw_status
+    fake_module.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+    fake_module.CNEntityTypeContacts = 7  # arbitrary; just must round-trip
+    monkeypatch.setitem(sys.modules, "Contacts", fake_module)
+    return cn_store_class
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (0, "notDetermined"),
+        (1, "restricted"),
+        (2, "denied"),
+        (3, "authorized"),
+        (4, "limited"),
+    ],
+)
+def test_run_cn_authorization_status_maps_each_known_value(
+    raw: int, expected: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cn_store_class = _install_contacts_with_status(monkeypatch, raw)
+    connector = ContactsConnector()
+    assert connector._run_cn_authorization_status() == expected
+    cn_store_class.authorizationStatusForEntityType_.assert_called_once_with(7)
+
+
+def test_run_cn_authorization_status_unknown_value_falls_back_to_not_determined(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _install_contacts_with_status(monkeypatch, 99)
+    connector = ContactsConnector()
+    with caplog.at_level("WARNING", logger="apple_contacts_mcp.contacts_connector"):
+        assert connector._run_cn_authorization_status() == "notDetermined"
+    assert any("Unknown CN authorization status" in r.message for r in caplog.records)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1,0 +1,55 @@
+"""Unit tests for @mcp.tool() functions in server.py."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from apple_contacts_mcp.server import check_authorization
+
+
+class TestCheckAuthorization:
+    @pytest.mark.parametrize("status", ["authorized", "limited"])
+    def test_granted_status_returns_no_remediation(self, status: str) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = status
+            result = check_authorization()
+        assert result == {"success": True, "status": status}
+
+    @pytest.mark.parametrize(
+        "status,remediation_substr",
+        [
+            ("notDetermined", "list_contacts"),
+            ("denied", "System Settings"),
+            ("restricted", "administrator"),
+        ],
+    )
+    def test_ungranted_status_includes_remediation(
+        self, status: str, remediation_substr: str
+    ) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = status
+            result = check_authorization()
+        assert result["success"] is True
+        assert result["status"] == status
+        assert remediation_substr in result["remediation"]
+
+    def test_connector_failure_returns_unknown_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.side_effect = RuntimeError(
+                "PyObjC import broke"
+            )
+            result: dict[str, Any] = check_authorization()
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "PyObjC import broke" in result["error"]
+
+    def test_response_keys_are_minimal_on_granted(self) -> None:
+        """Granted responses should not carry remediation noise."""
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            result = check_authorization()
+        assert "remediation" not in result
+        assert set(result.keys()) == {"success", "status"}


### PR DESCRIPTION
Closes #9.

## Summary

First public `@mcp.tool()`. Reports the current TCC authorization status for Contacts to the LLM.

```jsonc
// Granted
{"success": true, "status": "authorized"}
{"success": true, "status": "limited"}

// Not granted (status-specific remediation)
{"success": true, "status": "notDetermined", "remediation": "...trigger system prompt by calling list_contacts..."}
{"success": true, "status": "denied",        "remediation": "...System Settings → Privacy & Security..."}
{"success": true, "status": "restricted",    "remediation": "...locked by MDM / parental controls..."}

// Pure query failure (PyObjC broken)
{"success": false, "error": "...", "error_type": "unknown"}
```

## Design notes

- **Always `success: true` for query results**, including denied/restricted. Status-query tools succeed at *telling* you the state. `success: false` is reserved for the tool itself failing. Data-fetching tools (#10–#14) will use `success: false` + `error_type: "authorization_denied"` when TCC blocks them — the LLM then calls `check_authorization` to disambiguate.
- **Does not trigger the system prompt.** Per gap-analysis §3, for sync CLI flow we surface the state and let the user grant manually. The first data tool (`list_contacts`) will lazily call `_run_cn_request_access` to fire the prompt.
- **Connector helper added**: `_run_cn_authorization_status` — second `_run_cn_*` family member. Wraps the synchronous `+[CNContactStore authorizationStatusForEntityType:]` class method (no permission needed to call).

## Test plan

- [x] `make test` — 46 tests (13 new), all pass
- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy strict clean
- [x] `make coverage` — 96.95% project-wide; server.py at 96%
- [x] `make check-all` — full gate green; client/server parity now reports `check_authorization` tool

## Out of scope (deferred)

- Lazy `requestAccess` invocation on first data-tool use — handled by #10–#14 individually.
- Mid-process re-check at every data-tool entry — INITIAL_ISSUES.md item #33 (v0.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)