### PR TITLE
feat: list_contacts — paged read-only listing

### DIFF
--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 from .exceptions import (
     ContactsAppleScriptError,
     ContactsAuthorizationError,
+    ContactsError,
     ContactsTimeoutError,
 )
 
@@ -107,6 +108,61 @@ class ContactsConnector:
             logger.warning("Unknown CN authorization status: %d", raw)
             return "notDetermined"
         return status
+
+    def _run_cn_enumerate_contacts(
+        self, offset: int, limit: int
+    ) -> list[dict[str, str]]:
+        """Enumerate contacts and return basic-field dicts.
+
+        Implements pagination inside the enumeration callback: skip the
+        first `offset` contacts, then accumulate up to `limit` and signal
+        the framework to short-circuit via `stop_ptr[0] = True`. Without
+        the stop flag we'd pay the full O(N) walk even for a 50-element
+        page.
+        """
+        from Contacts import (
+            CNContactFamilyNameKey,
+            CNContactFetchRequest,
+            CNContactGivenNameKey,
+            CNContactIdentifierKey,
+            CNContactOrganizationNameKey,
+        )
+
+        keys = [
+            CNContactIdentifierKey,
+            CNContactGivenNameKey,
+            CNContactFamilyNameKey,
+            CNContactOrganizationNameKey,
+        ]
+        req = CNContactFetchRequest.alloc().initWithKeysToFetch_(keys)
+
+        contacts: list[dict[str, str]] = []
+        skipped = 0
+
+        def _collect(contact: Any, stop_ptr: Any) -> None:
+            nonlocal skipped
+            if skipped < offset:
+                skipped += 1
+                return
+            if len(contacts) >= limit:
+                stop_ptr[0] = True
+                return
+            contacts.append(
+                {
+                    "id": str(contact.identifier()),
+                    "given_name": str(contact.givenName()),
+                    "family_name": str(contact.familyName()),
+                    "organization": str(contact.organizationName()),
+                }
+            )
+
+        store = self._get_store()
+        ok, err = store.enumerateContactsWithFetchRequest_error_usingBlock_(
+            req, None, _collect
+        )
+        if not ok:
+            raise ContactsError(f"CN enumerate failed: {err}")
+        return contacts
 
     def _run_cn_request_access(self) -> bool:
         """Request TCC access to the Contacts entity. First `_run_cn_*` helper.

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastmcp import FastMCP
 
 from .contacts_connector import ContactsConnector
+from .exceptions import ContactsTimeoutError
 
 logging.basicConfig(
     level=logging.INFO,
@@ -17,6 +18,9 @@ logger = logging.getLogger(__name__)
 
 mcp: FastMCP = FastMCP("apple-contacts")
 connector = ContactsConnector()
+
+
+_LIST_CONTACTS_MAX = 200
 
 
 _AUTH_REMEDIATION: dict[str, str] = {
@@ -72,6 +76,113 @@ def check_authorization() -> dict[str, Any]:
     if status not in ("authorized", "limited"):
         response["remediation"] = _AUTH_REMEDIATION[status]
     return response
+
+
+def _require_contacts_authorization() -> dict[str, Any] | None:
+    """Returns None if access is granted; otherwise an error dict to return.
+
+    Reused by every data tool. Triggers the system permission prompt the
+    first time it sees ``notDetermined``.
+    """
+    try:
+        status = connector._run_cn_authorization_status()
+        if status == "notDetermined":
+            try:
+                connector._run_cn_request_access()
+            except ContactsTimeoutError:
+                return {
+                    "success": False,
+                    "error": (
+                        "Contacts permission prompt is awaiting your "
+                        "response. Grant access in the system dialog "
+                        "and retry."
+                    ),
+                    "error_type": "authorization_denied",
+                    "status": "notDetermined",
+                }
+            status = connector._run_cn_authorization_status()
+        if status in ("authorized", "limited"):
+            return None
+        return {
+            "success": False,
+            "status": status,
+            "error": f"Contacts access not granted (status={status}).",
+            "error_type": "authorization_denied",
+            "remediation": _AUTH_REMEDIATION.get(
+                status,
+                "Open System Settings → Privacy & Security → Contacts.",
+            ),
+        }
+    except Exception as exc:
+        logger.error("authorization check failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"Failed to check TCC status: {exc}",
+            "error_type": "unknown",
+        }
+
+
+@mcp.tool()
+def list_contacts(offset: int = 0, limit: int = 50) -> dict[str, Any]:
+    """List contacts (paged), each with id, given_name, family_name, organization.
+
+    Use ``get_contact(id)`` to fetch full details for a specific contact.
+    Use ``search_contacts(query)`` to filter by name. Order is not
+    guaranteed.
+
+    Args:
+        offset: Number of contacts to skip. Default 0. Must be >= 0.
+        limit:  Max contacts to return. Default 50. Capped at 200.
+
+    Returns:
+        On success: ``{"success": True, "contacts": [...], "count": N,
+        "offset": offset, "limit": effective_limit}``.
+        On TCC denial: ``{"success": False, "error_type":
+        "authorization_denied", "status": ..., "error": ..., "remediation":
+        ...}``.
+        On bad input: ``{"success": False, "error_type":
+        "validation_error", "error": ...}``.
+        On unexpected failure: ``{"success": False, "error_type":
+        "unknown", "error": ...}``.
+    """
+    if offset < 0:
+        return {
+            "success": False,
+            "error": "offset must be >= 0",
+            "error_type": "validation_error",
+        }
+    if limit < 1:
+        return {
+            "success": False,
+            "error": "limit must be >= 1",
+            "error_type": "validation_error",
+        }
+
+    effective_limit = min(limit, _LIST_CONTACTS_MAX)
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    try:
+        contacts = connector._run_cn_enumerate_contacts(
+            offset=offset, limit=effective_limit
+        )
+    except Exception as exc:
+        logger.error("list_contacts fetch failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"Fetch failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    return {
+        "success": True,
+        "contacts": contacts,
+        "count": len(contacts),
+        "offset": offset,
+        "limit": effective_limit,
+    }
 
 
 def main() -> None:

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -241,3 +241,161 @@ def test_run_cn_authorization_status_unknown_value_falls_back_to_not_determined(
     with caplog.at_level("WARNING", logger="apple_contacts_mcp.contacts_connector"):
         assert connector._run_cn_authorization_status() == "notDetermined"
     assert any("Unknown CN authorization status" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_enumerate_contacts
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_contact(
+    cn_id: str, given: str, family: str, org: str
+) -> MagicMock:
+    """Build a fake CNContact with the four selectors list_contacts reads."""
+    c = MagicMock(name=f"CNContact({cn_id})")
+    c.identifier.return_value = cn_id
+    c.givenName.return_value = given
+    c.familyName.return_value = family
+    c.organizationName.return_value = org
+    return c
+
+
+def _install_fake_contacts_for_enumerate(
+    monkeypatch: pytest.MonkeyPatch,
+    contacts: list[MagicMock],
+    enumerate_succeeds: bool = True,
+    fake_error: object | None = None,
+) -> MagicMock:
+    """Install a fake `Contacts` module + a store whose enumerate iterates
+    `contacts`, honoring the `stop_ptr[0] = True` short-circuit.
+
+    Returns the CNContactStore mock for assertion of call args.
+    """
+    fake_module = types.ModuleType("Contacts")
+    fake_module.CNContactIdentifierKey = "id_key"  # type: ignore[attr-defined]
+    fake_module.CNContactGivenNameKey = "given_key"  # type: ignore[attr-defined]
+    fake_module.CNContactFamilyNameKey = "family_key"  # type: ignore[attr-defined]
+    fake_module.CNContactOrganizationNameKey = "org_key"  # type: ignore[attr-defined]
+
+    # CNContactFetchRequest.alloc().initWithKeysToFetch_(keys) returns a request stub.
+    fetch_request_stub = MagicMock(name="CNContactFetchRequest_instance")
+    fetch_request_class = MagicMock(name="CNContactFetchRequest")
+    fetch_request_class.alloc.return_value.initWithKeysToFetch_.return_value = (
+        fetch_request_stub
+    )
+    fake_module.CNContactFetchRequest = fetch_request_class  # type: ignore[attr-defined]
+
+    cn_store_class = MagicMock(name="CNContactStore")
+    store_instance = MagicMock(name="store_instance")
+
+    def fake_enumerate(
+        _req: Any, _err: Any, callback: Any
+    ) -> tuple[bool, object | None]:
+        if not enumerate_succeeds:
+            return False, fake_error
+        for contact in contacts:
+            stop = [False]
+            callback(contact, stop)
+            if stop[0]:
+                break
+        return True, None
+
+    store_instance.enumerateContactsWithFetchRequest_error_usingBlock_.side_effect = (
+        fake_enumerate
+    )
+    cn_store_class.alloc.return_value.init.return_value = store_instance
+    fake_module.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "Contacts", fake_module)
+    return store_instance
+
+
+def test_enumerate_returns_empty_list_when_store_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_contacts_for_enumerate(monkeypatch, contacts=[])
+    connector = ContactsConnector()
+    assert connector._run_cn_enumerate_contacts(offset=0, limit=10) == []
+
+
+def test_enumerate_returns_all_when_under_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = [
+        _make_fake_contact(f"id-{i}", f"Given{i}", f"Family{i}", f"Org{i}")
+        for i in range(5)
+    ]
+    _install_fake_contacts_for_enumerate(monkeypatch, contacts=fakes)
+    connector = ContactsConnector()
+    result = connector._run_cn_enumerate_contacts(offset=0, limit=10)
+    assert len(result) == 5
+    assert result[0] == {
+        "id": "id-0",
+        "given_name": "Given0",
+        "family_name": "Family0",
+        "organization": "Org0",
+    }
+
+
+def test_enumerate_stops_after_limit_via_stop_ptr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = [
+        _make_fake_contact(f"id-{i}", f"G{i}", f"F{i}", f"O{i}") for i in range(10)
+    ]
+    _install_fake_contacts_for_enumerate(monkeypatch, contacts=fakes)
+    connector = ContactsConnector()
+    result = connector._run_cn_enumerate_contacts(offset=0, limit=3)
+    assert [c["id"] for c in result] == ["id-0", "id-1", "id-2"]
+    # Confirm later contacts' selectors were never accessed (stop short-circuited).
+    assert fakes[3].identifier.call_count == 0
+
+
+def test_enumerate_skips_offset_then_returns_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = [
+        _make_fake_contact(f"id-{i}", f"G{i}", f"F{i}", f"O{i}") for i in range(10)
+    ]
+    _install_fake_contacts_for_enumerate(monkeypatch, contacts=fakes)
+    connector = ContactsConnector()
+    result = connector._run_cn_enumerate_contacts(offset=4, limit=3)
+    assert [c["id"] for c in result] == ["id-4", "id-5", "id-6"]
+
+
+def test_enumerate_offset_past_end_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = [
+        _make_fake_contact(f"id-{i}", "G", "F", "O") for i in range(5)
+    ]
+    _install_fake_contacts_for_enumerate(monkeypatch, contacts=fakes)
+    connector = ContactsConnector()
+    assert connector._run_cn_enumerate_contacts(offset=20, limit=3) == []
+
+
+def test_enumerate_dict_keys_are_exactly_the_four_basic_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = [_make_fake_contact("id-0", "Alice", "Adams", "Acme")]
+    _install_fake_contacts_for_enumerate(monkeypatch, contacts=fakes)
+    connector = ContactsConnector()
+    [entry] = connector._run_cn_enumerate_contacts(offset=0, limit=1)
+    assert set(entry.keys()) == {"id", "given_name", "family_name", "organization"}
+
+
+def test_enumerate_raises_contacts_error_when_store_returns_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_error = MagicMock(name="NSError")
+    fake_error.__str__.return_value = "boom"
+    _install_fake_contacts_for_enumerate(
+        monkeypatch,
+        contacts=[],
+        enumerate_succeeds=False,
+        fake_error=fake_error,
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_enumerate_contacts(offset=0, limit=10)
+    assert "boom" in str(exc_info.value)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
-from apple_contacts_mcp.server import check_authorization
+from apple_contacts_mcp.exceptions import ContactsError, ContactsTimeoutError
+from apple_contacts_mcp.server import check_authorization, list_contacts
 
 
 class TestCheckAuthorization:
@@ -53,3 +54,170 @@ class TestCheckAuthorization:
             result = check_authorization()
         assert "remediation" not in result
         assert set(result.keys()) == {"success", "status"}
+
+
+# ---------------------------------------------------------------------------
+# list_contacts
+# ---------------------------------------------------------------------------
+
+
+_FAKE_CONTACTS = [
+    {"id": "id-0", "given_name": "Alice", "family_name": "Adams", "organization": "Acme"},
+    {"id": "id-1", "given_name": "Bob", "family_name": "Brown", "organization": ""},
+]
+
+
+class TestListContactsValidation:
+    def test_negative_offset_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = list_contacts(offset=-1)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        assert "offset" in result["error"]
+        mock_connector._run_cn_authorization_status.assert_not_called()
+        mock_connector._run_cn_enumerate_contacts.assert_not_called()
+
+    def test_zero_limit_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = list_contacts(limit=0)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        assert "limit" in result["error"]
+        mock_connector._run_cn_enumerate_contacts.assert_not_called()
+
+
+class TestListContactsAuthFlow:
+    @pytest.mark.parametrize("status", ["authorized", "limited"])
+    def test_granted_status_proceeds_to_fetch(self, status: str) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = status
+            mock_connector._run_cn_enumerate_contacts.return_value = _FAKE_CONTACTS
+            result = list_contacts()
+        assert result["success"] is True
+        assert result["contacts"] == _FAKE_CONTACTS
+        assert result["count"] == 2
+        assert result["offset"] == 0
+        assert result["limit"] == 50
+        mock_connector._run_cn_enumerate_contacts.assert_called_once_with(
+            offset=0, limit=50
+        )
+        mock_connector._run_cn_request_access.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "status,remediation_substr",
+        [
+            ("denied", "System Settings"),
+            ("restricted", "administrator"),
+        ],
+    )
+    def test_ungranted_status_returns_auth_denied(
+        self, status: str, remediation_substr: str
+    ) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = status
+            result = list_contacts()
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        assert result["status"] == status
+        assert remediation_substr in result["remediation"]
+        mock_connector._run_cn_enumerate_contacts.assert_not_called()
+        mock_connector._run_cn_request_access.assert_not_called()
+
+    def test_not_determined_then_granted_proceeds(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.side_effect = [
+                "notDetermined",
+                "authorized",
+            ]
+            mock_connector._run_cn_request_access.return_value = True
+            mock_connector._run_cn_enumerate_contacts.return_value = []
+            result = list_contacts()
+        assert result["success"] is True
+        mock_connector._run_cn_request_access.assert_called_once()
+        mock_connector._run_cn_enumerate_contacts.assert_called_once()
+
+    def test_not_determined_then_denied_returns_auth_denied(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.side_effect = [
+                "notDetermined",
+                "denied",
+            ]
+            mock_connector._run_cn_request_access.return_value = False
+            result = list_contacts()
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        assert result["status"] == "denied"
+        mock_connector._run_cn_enumerate_contacts.assert_not_called()
+
+    def test_request_access_timeout_returns_pending_message(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "notDetermined"
+            mock_connector._run_cn_request_access.side_effect = ContactsTimeoutError(
+                "no answer"
+            )
+            result = list_contacts()
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        assert result["status"] == "notDetermined"
+        assert "awaiting" in result["error"]
+        mock_connector._run_cn_enumerate_contacts.assert_not_called()
+
+    def test_authorization_status_raises_returns_unknown(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.side_effect = RuntimeError(
+                "PyObjC broke"
+            )
+            result = list_contacts()
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "PyObjC broke" in result["error"]
+
+
+class TestListContactsLimitClamp:
+    def test_limit_above_cap_is_clamped_to_200(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_enumerate_contacts.return_value = []
+            result = list_contacts(limit=500)
+        assert result["limit"] == 200
+        mock_connector._run_cn_enumerate_contacts.assert_called_once_with(
+            offset=0, limit=200
+        )
+
+    def test_limit_below_cap_is_passed_through(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_enumerate_contacts.return_value = []
+            result = list_contacts(limit=10)
+        assert result["limit"] == 10
+        mock_connector._run_cn_enumerate_contacts.assert_called_once_with(
+            offset=0, limit=10
+        )
+
+
+class TestListContactsFetchFailure:
+    def test_enumerate_raises_returns_unknown_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_enumerate_contacts.side_effect = ContactsError(
+                "enumerate boom"
+            )
+            result = list_contacts()
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "enumerate boom" in result["error"]
+
+
+class TestListContactsResponseShape:
+    def test_success_response_has_exact_keys(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_enumerate_contacts.return_value = _FAKE_CONTACTS
+            result = list_contacts()
+        assert set(result.keys()) == {
+            "success",
+            "contacts",
+            "count",
+            "offset",
+            "limit",
+        }


### PR DESCRIPTION
Closes #10.

## Summary

First **data-fetching** tool. Wraps `enumerateContactsWithFetchRequest_error_usingBlock_` against `CNContactStore`. Returns `[{id, given_name, family_name, organization}, ...]` with `offset`/`limit` pagination (default 50, hard cap 200).

```jsonc
list_contacts()
{
  "success": true,
  "contacts": [
    {"id": "ABCD...", "given_name": "Alice", "family_name": "Adams", "organization": "Acme"},
    ...
  ],
  "count": 50,
  "offset": 0,
  "limit": 50
}
```

## Design notes

- **Pagination via stop_ptr[0] = True.** Implemented inside the enumeration callback — skip the first `offset` contacts, then accumulate up to `limit` and signal the framework to short-circuit. Without the stop flag we'd pay the full O(N) walk even for a 50-element page (53 ms for 1696 contacts in the [Phase 0 baseline](docs/research/contacts-api-gap-analysis.md)).
- **Auth gate `_require_contacts_authorization()` extracted as a reusable helper** — data tools #11–#14 will share it. Triggers `requestAccess` the first time it sees `notDetermined`. Maps the four states (granted, denied, restricted, awaiting-prompt) to the right response envelope.
- **Adds the third `_run_cn_*` family member**: `_run_cn_enumerate_contacts(offset, limit)`. PyObjC bridges the `(BOOL, NSError**)` shape to a `(bool, NSError | None)` 2-tuple return; we unpack and raise `ContactsError` on `False`.
- **Read-only** — intentionally not in `DESTRUCTIVE_OPERATIONS`, so `check_test_mode_safety` doesn't gate it.

## Test plan

- [x] `make test` — 67 tests (21 new), all pass
- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy strict clean
- [x] `make coverage` — 97.81% project-wide
- [x] `make check-all` — full gate green; client/server parity reports `check_authorization` and `list_contacts`

## Out of scope (deferred)

- Real-Contacts integration test → #15 (the integration test rig).
- Sort order arg → CN's enumeration order is implementation-defined; documented as "not guaranteed" in the docstring.
- Filter by group / container → not in #10's scope.
- Performance benchmark → v0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)