### PR TITLE
feat: get_contact — full P1 contact dict by identifier

### DIFF
--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import subprocess
 import threading
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from .exceptions import (
@@ -164,6 +165,56 @@ class ContactsConnector:
             raise ContactsError(f"CN enumerate failed: {err}")
         return contacts
 
+    def _run_cn_unified_contact(
+        self, identifier: str
+    ) -> dict[str, Any] | None:
+        """Fetch a single contact by identifier with the full P1 key set.
+
+        Returns the serialized dict, or None if no contact matches.
+        """
+        from Contacts import (
+            CNContactBirthdayKey,
+            CNContactDepartmentNameKey,
+            CNContactEmailAddressesKey,
+            CNContactFamilyNameKey,
+            CNContactGivenNameKey,
+            CNContactJobTitleKey,
+            CNContactMiddleNameKey,
+            CNContactNamePrefixKey,
+            CNContactNameSuffixKey,
+            CNContactNicknameKey,
+            CNContactOrganizationNameKey,
+            CNContactPhoneNumbersKey,
+            CNContactPostalAddressesKey,
+            CNContactUrlAddressesKey,
+            CNLabeledValue,
+        )
+
+        keys = [
+            CNContactGivenNameKey,
+            CNContactFamilyNameKey,
+            CNContactMiddleNameKey,
+            CNContactNamePrefixKey,
+            CNContactNameSuffixKey,
+            CNContactNicknameKey,
+            CNContactOrganizationNameKey,
+            CNContactJobTitleKey,
+            CNContactDepartmentNameKey,
+            CNContactPhoneNumbersKey,
+            CNContactEmailAddressesKey,
+            CNContactPostalAddressesKey,
+            CNContactUrlAddressesKey,
+            CNContactBirthdayKey,
+        ]
+
+        store = self._get_store()
+        contact, _err = store.unifiedContactWithIdentifier_keysToFetch_error_(
+            identifier, keys, None
+        )
+        if contact is None:
+            return None
+        return _serialize_contact(contact, CNLabeledValue)
+
     def _run_cn_request_access(self) -> bool:
         """Request TCC access to the Contacts entity. First `_run_cn_*` helper.
 
@@ -202,3 +253,103 @@ class ContactsConnector:
             raise ContactsAuthorizationError(str(result["error"]))
 
         return bool(result["granted"])
+
+
+# ---------------------------------------------------------------------------
+# CNContact serializers (module-private)
+# ---------------------------------------------------------------------------
+
+
+def _serialize_contact(contact: Any, CNLabeledValue: Any) -> dict[str, Any]:
+    return {
+        "id": str(contact.identifier()),
+        "given_name": str(contact.givenName()),
+        "family_name": str(contact.familyName()),
+        "middle_name": str(contact.middleName()),
+        "name_prefix": str(contact.namePrefix()),
+        "name_suffix": str(contact.nameSuffix()),
+        "nickname": str(contact.nickname()),
+        "organization": str(contact.organizationName()),
+        "job_title": str(contact.jobTitle()),
+        "department": str(contact.departmentName()),
+        "phones": _serialize_labeled_values(
+            contact.phoneNumbers(),
+            CNLabeledValue,
+            lambda v: {"value": str(v.stringValue())},
+        ),
+        "emails": _serialize_labeled_values(
+            contact.emailAddresses(),
+            CNLabeledValue,
+            lambda v: {"value": str(v)},
+        ),
+        "urls": _serialize_labeled_values(
+            contact.urlAddresses(),
+            CNLabeledValue,
+            lambda v: {"value": str(v)},
+        ),
+        "postal_addresses": _serialize_labeled_values(
+            contact.postalAddresses(),
+            CNLabeledValue,
+            _serialize_postal_address,
+        ),
+        "birthday": _serialize_birthday(contact.birthday()),
+    }
+
+
+def _serialize_labeled_values(
+    items: Any,
+    CNLabeledValue: Any,
+    value_fn: Callable[[Any], dict[str, Any]],
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if items is None:
+        return out
+    for item in items:
+        raw = item.label()
+        if raw is None:
+            label_raw = ""
+            human = ""
+        else:
+            label_raw = str(raw)
+            human = str(CNLabeledValue.localizedStringForLabel_(raw))
+        entry: dict[str, Any] = {"label_raw": label_raw, "label": human}
+        entry.update(value_fn(item.value()))
+        out.append(entry)
+    return out
+
+
+def _serialize_postal_address(addr: Any) -> dict[str, str]:
+    return {
+        "street": str(addr.street()),
+        "sub_locality": str(addr.subLocality()),
+        "city": str(addr.city()),
+        "sub_administrative_area": str(addr.subAdministrativeArea()),
+        "state": str(addr.state()),
+        "postal_code": str(addr.postalCode()),
+        "country": str(addr.country()),
+        "iso_country_code": str(addr.ISOCountryCode()),
+    }
+
+
+def _serialize_birthday(date_components: Any) -> dict[str, int] | None:
+    """Serialize NSDateComponents → {year?, month?, day?} or None.
+
+    Apple uses NSNotFound (≈ NSIntegerMax) for unset components and lets
+    users set a birthday without a year. Filter via 0 < val < 10_000.
+    """
+    if date_components is None:
+        return None
+
+    def _safe(v: Any) -> int | None:
+        try:
+            n = int(v)
+        except (TypeError, ValueError):
+            return None
+        return n if 0 < n < 10_000 else None
+
+    out: dict[str, int] = {}
+    for attr, key in (("year", "year"), ("month", "month"), ("day", "day")):
+        v = _safe(getattr(date_components, attr)())
+        if v is not None:
+            out[key] = v
+    return out or None

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -185,6 +185,63 @@ def list_contacts(offset: int = 0, limit: int = 50) -> dict[str, Any]:
     }
 
 
+@mcp.tool()
+def get_contact(identifier: str) -> dict[str, Any]:
+    """Fetch a single contact by its CN identifier with all P1 fields.
+
+    Get an identifier from ``list_contacts`` or ``search_contacts``, then
+    call this for the full record (name parts, organization, phones,
+    emails, postal addresses, urls, birthday).
+
+    Args:
+        identifier: The contact's CN identifier (UUID-shaped string).
+
+    Returns:
+        On success: ``{"success": True, "contact": {...full P1 fields...}}``.
+        On missing identifier (no such contact): ``{"success": False,
+        "error_type": "not_found", "error": ...}``.
+        On bad input (empty string): ``{"success": False, "error_type":
+        "validation_error", "error": ...}``.
+        On TCC denial: same shape as ``list_contacts`` (status,
+        remediation).
+        On unexpected failure: ``{"success": False, "error_type":
+        "unknown", "error": ...}``.
+
+    Each entry in the labeled-value families (phones, emails, urls,
+    postal_addresses) carries both ``label_raw`` (the
+    ``_$!<...>!$_`` token) and ``label`` (the human string).
+    """
+    if not identifier or not identifier.strip():
+        return {
+            "success": False,
+            "error": "identifier must be a non-empty string",
+            "error_type": "validation_error",
+        }
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    try:
+        contact = connector._run_cn_unified_contact(identifier)
+    except Exception as exc:
+        logger.error("get_contact fetch failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"Fetch failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    if contact is None:
+        return {
+            "success": False,
+            "error": f"No contact found with identifier {identifier!r}",
+            "error_type": "not_found",
+        }
+
+    return {"success": True, "contact": contact}
+
+
 def main() -> None:
     """Start the MCP server."""
     mcp.run()

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -399,3 +399,295 @@ def test_enumerate_raises_contacts_error_when_store_returns_failure(
     with pytest.raises(ContactsError) as exc_info:
         connector._run_cn_enumerate_contacts(offset=0, limit=10)
     assert "boom" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_unified_contact
+# ---------------------------------------------------------------------------
+
+
+_LOCALIZED_LABELS = {
+    "_$!<Mobile>!$_": "mobile",
+    "_$!<Home>!$_": "home",
+    "_$!<Work>!$_": "work",
+    "_$!<HomePage>!$_": "homepage",
+}
+
+
+def _make_phone(value: str) -> MagicMock:
+    p = MagicMock(name=f"CNPhoneNumber({value})")
+    p.stringValue.return_value = value
+    return p
+
+
+def _make_postal(**fields: str) -> MagicMock:
+    """Build a fake CNPostalAddress with all 8 selectors."""
+    a = MagicMock(name="CNPostalAddress")
+    a.street.return_value = fields.get("street", "")
+    a.subLocality.return_value = fields.get("sub_locality", "")
+    a.city.return_value = fields.get("city", "")
+    a.subAdministrativeArea.return_value = fields.get("sub_administrative_area", "")
+    a.state.return_value = fields.get("state", "")
+    a.postalCode.return_value = fields.get("postal_code", "")
+    a.country.return_value = fields.get("country", "")
+    a.ISOCountryCode.return_value = fields.get("iso_country_code", "")
+    return a
+
+
+def _make_labeled(label: str | None, value: Any) -> MagicMock:
+    lv = MagicMock(name=f"CNLabeledValue({label!r})")
+    lv.label.return_value = label
+    lv.value.return_value = value
+    return lv
+
+
+def _make_birthday(
+    year: int | None = None, month: int | None = None, day: int | None = None
+) -> MagicMock:
+    """Build a fake NSDateComponents.
+
+    `None` for any component means "set to NSIntegerMax" (the undefined
+    sentinel CN actually returns).
+    """
+    UNDEFINED = 9223372036854775807
+    bd = MagicMock(name="NSDateComponents")
+    bd.year.return_value = UNDEFINED if year is None else year
+    bd.month.return_value = UNDEFINED if month is None else month
+    bd.day.return_value = UNDEFINED if day is None else day
+    return bd
+
+
+def _make_full_contact(
+    cn_id: str = "ABCD",
+    given: str = "Alice",
+    family: str = "Adams",
+    middle: str = "M",
+    prefix: str = "Dr.",
+    suffix: str = "Jr.",
+    nickname: str = "Ali",
+    organization: str = "Acme",
+    job: str = "Engineer",
+    department: str = "R&D",
+    phones: list[MagicMock] | None = None,
+    emails: list[MagicMock] | None = None,
+    urls: list[MagicMock] | None = None,
+    postal: list[MagicMock] | None = None,
+    birthday: MagicMock | None = None,
+) -> MagicMock:
+    c = MagicMock(name=f"CNContact({cn_id})")
+    c.identifier.return_value = cn_id
+    c.givenName.return_value = given
+    c.familyName.return_value = family
+    c.middleName.return_value = middle
+    c.namePrefix.return_value = prefix
+    c.nameSuffix.return_value = suffix
+    c.nickname.return_value = nickname
+    c.organizationName.return_value = organization
+    c.jobTitle.return_value = job
+    c.departmentName.return_value = department
+    c.phoneNumbers.return_value = phones or []
+    c.emailAddresses.return_value = emails or []
+    c.urlAddresses.return_value = urls or []
+    c.postalAddresses.return_value = postal or []
+    c.birthday.return_value = birthday
+    return c
+
+
+def _install_fake_contacts_for_unified(
+    monkeypatch: pytest.MonkeyPatch,
+    contact: MagicMock | None,
+    fake_error: object | None = None,
+) -> MagicMock:
+    """Install a fake `Contacts` module + a store whose
+    unifiedContactWithIdentifier... returns (contact, fake_error).
+    """
+    fake_module = types.ModuleType("Contacts")
+    for k in (
+        "CNContactGivenNameKey",
+        "CNContactFamilyNameKey",
+        "CNContactMiddleNameKey",
+        "CNContactNamePrefixKey",
+        "CNContactNameSuffixKey",
+        "CNContactNicknameKey",
+        "CNContactOrganizationNameKey",
+        "CNContactJobTitleKey",
+        "CNContactDepartmentNameKey",
+        "CNContactPhoneNumbersKey",
+        "CNContactEmailAddressesKey",
+        "CNContactPostalAddressesKey",
+        "CNContactUrlAddressesKey",
+        "CNContactBirthdayKey",
+    ):
+        setattr(fake_module, k, k)
+
+    cn_labeled_value = MagicMock(name="CNLabeledValue")
+    cn_labeled_value.localizedStringForLabel_.side_effect = (
+        lambda raw: _LOCALIZED_LABELS.get(raw, raw)
+    )
+    fake_module.CNLabeledValue = cn_labeled_value  # type: ignore[attr-defined]
+
+    cn_store_class = MagicMock(name="CNContactStore")
+    store_instance = MagicMock(name="store_instance")
+    store_instance.unifiedContactWithIdentifier_keysToFetch_error_.return_value = (
+        contact,
+        fake_error,
+    )
+    cn_store_class.alloc.return_value.init.return_value = store_instance
+    fake_module.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "Contacts", fake_module)
+    return store_instance
+
+
+def test_unified_contact_returns_none_when_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_error = MagicMock(name="NSError")
+    _install_fake_contacts_for_unified(
+        monkeypatch, contact=None, fake_error=fake_error
+    )
+    connector = ContactsConnector()
+    assert connector._run_cn_unified_contact("nonexistent") is None
+
+
+def test_unified_contact_full_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    contact = _make_full_contact(
+        phones=[_make_labeled("_$!<Mobile>!$_", _make_phone("+1 555-1212"))],
+        emails=[_make_labeled("_$!<Home>!$_", "alice@example.com")],
+        urls=[_make_labeled("_$!<HomePage>!$_", "https://acme.example")],
+        postal=[
+            _make_labeled(
+                "_$!<Work>!$_",
+                _make_postal(
+                    street="1 Loop", city="Cupertino", state="CA",
+                    postal_code="95014", country="USA", iso_country_code="us",
+                ),
+            )
+        ],
+        birthday=_make_birthday(year=1990, month=5, day=15),
+    )
+    store = _install_fake_contacts_for_unified(monkeypatch, contact=contact)
+    connector = ContactsConnector()
+
+    result = connector._run_cn_unified_contact("ABCD")
+
+    assert result is not None
+    assert result["id"] == "ABCD"
+    assert result["given_name"] == "Alice"
+    assert result["family_name"] == "Adams"
+    assert result["middle_name"] == "M"
+    assert result["name_prefix"] == "Dr."
+    assert result["name_suffix"] == "Jr."
+    assert result["nickname"] == "Ali"
+    assert result["organization"] == "Acme"
+    assert result["job_title"] == "Engineer"
+    assert result["department"] == "R&D"
+    assert result["phones"] == [
+        {"label_raw": "_$!<Mobile>!$_", "label": "mobile", "value": "+1 555-1212"}
+    ]
+    assert result["emails"] == [
+        {"label_raw": "_$!<Home>!$_", "label": "home", "value": "alice@example.com"}
+    ]
+    assert result["urls"] == [
+        {
+            "label_raw": "_$!<HomePage>!$_",
+            "label": "homepage",
+            "value": "https://acme.example",
+        }
+    ]
+    assert result["postal_addresses"] == [
+        {
+            "label_raw": "_$!<Work>!$_",
+            "label": "work",
+            "street": "1 Loop",
+            "sub_locality": "",
+            "city": "Cupertino",
+            "sub_administrative_area": "",
+            "state": "CA",
+            "postal_code": "95014",
+            "country": "USA",
+            "iso_country_code": "us",
+        }
+    ]
+    assert result["birthday"] == {"year": 1990, "month": 5, "day": 15}
+
+    store.unifiedContactWithIdentifier_keysToFetch_error_.assert_called_once()
+    args, _ = store.unifiedContactWithIdentifier_keysToFetch_error_.call_args
+    assert args[0] == "ABCD"
+    assert "CNContactGivenNameKey" in args[1]
+    assert "CNContactBirthdayKey" in args[1]
+
+
+def test_unified_contact_empty_multivalued_fields_become_empty_lists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contact = _make_full_contact()  # all defaults; no phones/emails/etc.
+    _install_fake_contacts_for_unified(monkeypatch, contact=contact)
+    connector = ContactsConnector()
+
+    result = connector._run_cn_unified_contact("ABCD")
+    assert result is not None
+    assert result["phones"] == []
+    assert result["emails"] == []
+    assert result["urls"] == []
+    assert result["postal_addresses"] == []
+    assert result["birthday"] is None
+
+
+def test_unified_contact_custom_label_passes_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contact = _make_full_contact(
+        phones=[_make_labeled("buzzer", _make_phone("+1 555-9999"))]
+    )
+    _install_fake_contacts_for_unified(monkeypatch, contact=contact)
+    connector = ContactsConnector()
+
+    result = connector._run_cn_unified_contact("ABCD")
+    assert result is not None
+    assert result["phones"] == [
+        {"label_raw": "buzzer", "label": "buzzer", "value": "+1 555-9999"}
+    ]
+
+
+def test_unified_contact_none_label_becomes_empty_strings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contact = _make_full_contact(
+        emails=[_make_labeled(None, "anon@example.com")]
+    )
+    _install_fake_contacts_for_unified(monkeypatch, contact=contact)
+    connector = ContactsConnector()
+
+    result = connector._run_cn_unified_contact("ABCD")
+    assert result is not None
+    assert result["emails"] == [
+        {"label_raw": "", "label": "", "value": "anon@example.com"}
+    ]
+
+
+def test_unified_contact_birthday_year_undefined(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contact = _make_full_contact(
+        birthday=_make_birthday(year=None, month=5, day=15)
+    )
+    _install_fake_contacts_for_unified(monkeypatch, contact=contact)
+    connector = ContactsConnector()
+
+    result = connector._run_cn_unified_contact("ABCD")
+    assert result is not None
+    assert result["birthday"] == {"month": 5, "day": 15}
+    assert "year" not in result["birthday"]
+
+
+def test_unified_contact_birthday_all_components_zero_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contact = _make_full_contact(birthday=_make_birthday(year=0, month=0, day=0))
+    _install_fake_contacts_for_unified(monkeypatch, contact=contact)
+    connector = ContactsConnector()
+
+    result = connector._run_cn_unified_contact("ABCD")
+    assert result is not None
+    assert result["birthday"] is None

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -8,7 +8,11 @@ from unittest.mock import patch
 import pytest
 
 from apple_contacts_mcp.exceptions import ContactsError, ContactsTimeoutError
-from apple_contacts_mcp.server import check_authorization, list_contacts
+from apple_contacts_mcp.server import (
+    check_authorization,
+    get_contact,
+    list_contacts,
+)
 
 
 class TestCheckAuthorization:
@@ -221,3 +225,92 @@ class TestListContactsResponseShape:
             "offset",
             "limit",
         }
+
+
+# ---------------------------------------------------------------------------
+# get_contact
+# ---------------------------------------------------------------------------
+
+
+_FAKE_CONTACT_DICT: dict[str, Any] = {
+    "id": "ABCD",
+    "given_name": "Alice",
+    "family_name": "Adams",
+    "middle_name": "",
+    "name_prefix": "",
+    "name_suffix": "",
+    "nickname": "",
+    "organization": "Acme",
+    "job_title": "",
+    "department": "",
+    "phones": [],
+    "emails": [],
+    "urls": [],
+    "postal_addresses": [],
+    "birthday": None,
+}
+
+
+class TestGetContactValidation:
+    @pytest.mark.parametrize("identifier", ["", "   ", "\t\n"])
+    def test_blank_identifier_returns_validation_error(
+        self, identifier: str
+    ) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = get_contact(identifier)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        assert "identifier" in result["error"]
+        mock_connector._run_cn_authorization_status.assert_not_called()
+        mock_connector._run_cn_unified_contact.assert_not_called()
+
+
+class TestGetContactAuthFlow:
+    def test_auth_denied_passthrough_skips_fetch(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "denied"
+            result = get_contact("ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        mock_connector._run_cn_unified_contact.assert_not_called()
+
+
+class TestGetContactFound:
+    def test_found_returns_contact_dict(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_unified_contact.return_value = _FAKE_CONTACT_DICT
+            result = get_contact("ABCD")
+        assert result == {"success": True, "contact": _FAKE_CONTACT_DICT}
+        mock_connector._run_cn_unified_contact.assert_called_once_with("ABCD")
+
+    def test_response_keys_are_minimal_on_success(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_unified_contact.return_value = _FAKE_CONTACT_DICT
+            result = get_contact("ABCD")
+        assert set(result.keys()) == {"success", "contact"}
+
+
+class TestGetContactNotFound:
+    def test_none_from_connector_maps_to_not_found(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_unified_contact.return_value = None
+            result = get_contact("ZZZZ")
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+        assert "ZZZZ" in result["error"]
+
+
+class TestGetContactConnectorRaises:
+    def test_unexpected_exception_returns_unknown_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_unified_contact.side_effect = ContactsError(
+                "boom"
+            )
+            result = get_contact("ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "boom" in result["error"]


### PR DESCRIPTION
Closes #11.

## Summary

Second data tool. Fetches a single contact by CN identifier with the full P1 key set: name parts + nickname, organization triplet, four labeled-value families (phones / emails / postal / urls), and birthday.

```jsonc
get_contact("ABCD-1234-...")
{
  "success": true,
  "contact": {
    "id": "ABCD-1234-...",
    "given_name": "Alice", "family_name": "Adams", "middle_name": "",
    "name_prefix": "", "name_suffix": "", "nickname": "",
    "organization": "Acme", "job_title": "", "department": "",
    "phones": [
      {"label_raw": "_$!<Mobile>!$_", "label": "mobile", "value": "+1 555-1212"}
    ],
    "emails": [...], "urls": [...],
    "postal_addresses": [
      {"label_raw": "_$!<Work>!$_", "label": "work",
       "street": "1 Loop", "sub_locality": "", "city": "Cupertino",
       "sub_administrative_area": "", "state": "CA",
       "postal_code": "95014", "country": "USA", "iso_country_code": "us"}
    ],
    "birthday": {"year": 1990, "month": 5, "day": 15}
  }
}
```

## Design notes

- **Both label forms emitted per labeled value.** `label_raw` = `_$!<Mobile>!$_`; `label` = `mobile` via `CNLabeledValue.localizedStringForLabel_`. Reverse mapping (create/update) is v0.2.0 issue #18.
- **Birthday handling.** Apple lets users add a birthday without a year — NSDateComponents marks unset fields with NSNotFound (≈ NSIntegerMax). Filter via `0 < val < 10_000` so the response carries only defined components. Empty birthday → `null`.
- **Empty multi-valued fields surface as `[]`**, not omitted, so the LLM doesn't need to handle missing keys.
- **Not-found semantics.** PyObjC returns `(None, NSError)` for missing identifiers. We treat any `contact is None` post-auth as not-found and emit `error_type: "not_found"`. Mid-flight TCC revocation handling is v0.4.0 (#33).
- **Fourth `_run_cn_*` helper** added (`_run_cn_unified_contact`). Four module-private serializers (`_serialize_contact`, `_serialize_labeled_values`, `_serialize_postal_address`, `_serialize_birthday`) live next to it for future reuse.
- **Reuses `_require_contacts_authorization()`** from #10 — no new server-layer infrastructure.

## Test plan

- [x] `make test` — 82 tests (15 new), all pass
- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy strict clean
- [x] `make coverage` — 97.10% project-wide
- [x] `make check-all` — full gate green; client/server parity reports `check_authorization`, `get_contact`, `list_contacts`

## Out of scope (deferred)

- Real-Contacts integration test → #15.
- Reverse label mapping (string → token, for create/update) → v0.2.0 issue #18.
- Note field (entitlement-gated, AppleScript fallback) → not P1.
- Profile photo data → future MCP-resource-style tool.
- Group memberships, modification/creation dates → v0.2.0+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)