### PR TITLE
feat: search_contacts — predicate by name

### DIFF
--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -165,6 +165,51 @@ class ContactsConnector:
             raise ContactsError(f"CN enumerate failed: {err}")
         return contacts
 
+    def _run_cn_search_contacts(
+        self, query: str, limit: int
+    ) -> list[dict[str, str]]:
+        """Search contacts by name predicate, returning basic-field dicts.
+
+        Predicate execution is offloaded to the framework — fast even on
+        large address books. We slice to ``limit`` *while serializing*
+        so we don't pay full O(N_matches) for entries we'll throw away.
+        """
+        from Contacts import (
+            CNContact,
+            CNContactFamilyNameKey,
+            CNContactGivenNameKey,
+            CNContactIdentifierKey,
+            CNContactOrganizationNameKey,
+        )
+
+        keys = [
+            CNContactIdentifierKey,
+            CNContactGivenNameKey,
+            CNContactFamilyNameKey,
+            CNContactOrganizationNameKey,
+        ]
+        pred = CNContact.predicateForContactsMatchingName_(query)
+        store = self._get_store()
+        results, err = store.unifiedContactsMatchingPredicate_keysToFetch_error_(
+            pred, keys, None
+        )
+        if results is None:
+            raise ContactsError(f"CN search failed: {err}")
+
+        out: list[dict[str, str]] = []
+        for contact in results:
+            if len(out) >= limit:
+                break
+            out.append(
+                {
+                    "id": str(contact.identifier()),
+                    "given_name": str(contact.givenName()),
+                    "family_name": str(contact.familyName()),
+                    "organization": str(contact.organizationName()),
+                }
+            )
+        return out
+
     def _run_cn_unified_contact(
         self, identifier: str
     ) -> dict[str, Any] | None:

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -21,6 +21,7 @@ connector = ContactsConnector()
 
 
 _LIST_CONTACTS_MAX = 200
+_SEARCH_CONTACTS_MAX = 200
 
 
 _AUTH_REMEDIATION: dict[str, str] = {
@@ -240,6 +241,62 @@ def get_contact(identifier: str) -> dict[str, Any]:
         }
 
     return {"success": True, "contact": contact}
+
+
+@mcp.tool()
+def search_contacts(query: str) -> dict[str, Any]:
+    """Find contacts whose name matches `query` (substring, case-insensitive).
+
+    Matches given/family/organization names via Apple's built-in
+    ``predicateForContactsMatchingName:``. Returns up to 200 results
+    (hard cap). Use ``list_contacts`` for unfiltered iteration;
+    ``get_contact(id)`` for full details on a specific result. Order
+    is not guaranteed.
+
+    Args:
+        query: Substring to match. Must be a non-empty string.
+
+    Returns:
+        On success: ``{"success": True, "contacts": [...], "count": N,
+        "query": query, "limit": 200}``. ``count == limit`` indicates
+        the cap was hit and there may be more matches.
+        On bad input: ``{"success": False, "error_type":
+        "validation_error", "error": ...}``.
+        On TCC denial: same shape as ``list_contacts`` (status,
+        remediation).
+        On unexpected failure: ``{"success": False, "error_type":
+        "unknown", "error": ...}``.
+    """
+    if not query or not query.strip():
+        return {
+            "success": False,
+            "error": "query must be a non-empty string",
+            "error_type": "validation_error",
+        }
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    try:
+        contacts = connector._run_cn_search_contacts(
+            query=query, limit=_SEARCH_CONTACTS_MAX
+        )
+    except Exception as exc:
+        logger.error("search_contacts fetch failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"Search failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    return {
+        "success": True,
+        "contacts": contacts,
+        "count": len(contacts),
+        "query": query,
+        "limit": _SEARCH_CONTACTS_MAX,
+    }
 
 
 def main() -> None:

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -691,3 +691,128 @@ def test_unified_contact_birthday_all_components_zero_returns_none(
     result = connector._run_cn_unified_contact("ABCD")
     assert result is not None
     assert result["birthday"] is None
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_search_contacts
+# ---------------------------------------------------------------------------
+
+
+def _make_basic_contact(
+    cn_id: str, given: str = "G", family: str = "F", org: str = "O"
+) -> MagicMock:
+    """Build a fake CNContact with only the four basic selectors."""
+    c = MagicMock(name=f"CNContact({cn_id})")
+    c.identifier.return_value = cn_id
+    c.givenName.return_value = given
+    c.familyName.return_value = family
+    c.organizationName.return_value = org
+    return c
+
+
+def _install_fake_contacts_for_search(
+    monkeypatch: pytest.MonkeyPatch,
+    results: list[MagicMock] | None,
+    fake_error: object | None = None,
+) -> tuple[MagicMock, MagicMock]:
+    """Install a fake `Contacts` module + a store whose
+    unifiedContactsMatchingPredicate... returns (results, fake_error).
+
+    Returns (CNContact_class_mock, store_instance_mock) for assertions.
+    """
+    fake_module = types.ModuleType("Contacts")
+    fake_module.CNContactIdentifierKey = "id_key"  # type: ignore[attr-defined]
+    fake_module.CNContactGivenNameKey = "given_key"  # type: ignore[attr-defined]
+    fake_module.CNContactFamilyNameKey = "family_key"  # type: ignore[attr-defined]
+    fake_module.CNContactOrganizationNameKey = "org_key"  # type: ignore[attr-defined]
+
+    cn_contact_class = MagicMock(name="CNContact")
+    pred_stub = MagicMock(name="NSPredicate")
+    cn_contact_class.predicateForContactsMatchingName_.return_value = pred_stub
+    fake_module.CNContact = cn_contact_class  # type: ignore[attr-defined]
+
+    cn_store_class = MagicMock(name="CNContactStore")
+    store_instance = MagicMock(name="store_instance")
+    store_instance.unifiedContactsMatchingPredicate_keysToFetch_error_.return_value = (
+        results,
+        fake_error,
+    )
+    cn_store_class.alloc.return_value.init.return_value = store_instance
+    fake_module.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "Contacts", fake_module)
+    return cn_contact_class, store_instance
+
+
+def test_search_returns_empty_when_no_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_contacts_for_search(monkeypatch, results=[])
+    connector = ContactsConnector()
+    assert connector._run_cn_search_contacts(query="nobody", limit=200) == []
+
+
+def test_search_returns_dicts_for_each_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = [
+        _make_basic_contact("id-0", "John", "Smith", "Acme"),
+        _make_basic_contact("id-1", "Johnny", "Walker", ""),
+    ]
+    _install_fake_contacts_for_search(monkeypatch, results=fakes)
+    connector = ContactsConnector()
+    result = connector._run_cn_search_contacts(query="john", limit=200)
+    assert result == [
+        {"id": "id-0", "given_name": "John", "family_name": "Smith", "organization": "Acme"},
+        {"id": "id-1", "given_name": "Johnny", "family_name": "Walker", "organization": ""},
+    ]
+
+
+def test_search_caps_results_at_limit_and_skips_serializing_extras(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = [_make_basic_contact(f"id-{i}") for i in range(250)]
+    _install_fake_contacts_for_search(monkeypatch, results=fakes)
+    connector = ContactsConnector()
+    result = connector._run_cn_search_contacts(query="x", limit=200)
+    assert len(result) == 200
+    assert result[0]["id"] == "id-0"
+    assert result[-1]["id"] == "id-199"
+    # 201st contact's selectors must never have been touched.
+    assert fakes[200].identifier.call_count == 0
+
+
+def test_search_calls_predicate_with_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cn_contact_class, _ = _install_fake_contacts_for_search(monkeypatch, results=[])
+    connector = ContactsConnector()
+    connector._run_cn_search_contacts(query="alice", limit=200)
+    cn_contact_class.predicateForContactsMatchingName_.assert_called_once_with(
+        "alice"
+    )
+
+
+def test_search_dict_keys_are_exactly_the_four_basic_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_contacts_for_search(
+        monkeypatch, results=[_make_basic_contact("id-0", "A", "B", "C")]
+    )
+    connector = ContactsConnector()
+    [entry] = connector._run_cn_search_contacts(query="a", limit=200)
+    assert set(entry.keys()) == {"id", "given_name", "family_name", "organization"}
+
+
+def test_search_raises_contacts_error_when_results_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_error = MagicMock(name="NSError")
+    fake_error.__str__.return_value = "boom"
+    _install_fake_contacts_for_search(
+        monkeypatch, results=None, fake_error=fake_error
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_search_contacts(query="x", limit=200)
+    assert "boom" in str(exc_info.value)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -12,6 +12,7 @@ from apple_contacts_mcp.server import (
     check_authorization,
     get_contact,
     list_contacts,
+    search_contacts,
 )
 
 
@@ -311,6 +312,112 @@ class TestGetContactConnectorRaises:
                 "boom"
             )
             result = get_contact("ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# search_contacts
+# ---------------------------------------------------------------------------
+
+
+_FAKE_SEARCH_HITS = [
+    {"id": "id-0", "given_name": "John", "family_name": "Smith", "organization": "Acme"},
+    {"id": "id-1", "given_name": "Johnny", "family_name": "Walker", "organization": ""},
+    {"id": "id-2", "given_name": "John", "family_name": "Doe", "organization": "Foo"},
+]
+
+
+class TestSearchContactsValidation:
+    @pytest.mark.parametrize("query", ["", "   ", "\t", "\n  \t"])
+    def test_blank_query_returns_validation_error(self, query: str) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = search_contacts(query)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        assert "query" in result["error"]
+        mock_connector._run_cn_authorization_status.assert_not_called()
+        mock_connector._run_cn_search_contacts.assert_not_called()
+
+
+class TestSearchContactsAuthFlow:
+    def test_auth_denied_passthrough_skips_search(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "denied"
+            result = search_contacts("john")
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        mock_connector._run_cn_search_contacts.assert_not_called()
+
+
+class TestSearchContactsHappyPath:
+    def test_returns_results_with_query_and_limit_echoed(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_search_contacts.return_value = _FAKE_SEARCH_HITS
+            result = search_contacts("john")
+        assert result == {
+            "success": True,
+            "contacts": _FAKE_SEARCH_HITS,
+            "count": 3,
+            "query": "john",
+            "limit": 200,
+        }
+
+    def test_response_keys_are_minimal_on_success(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_search_contacts.return_value = _FAKE_SEARCH_HITS
+            result = search_contacts("john")
+        assert set(result.keys()) == {
+            "success",
+            "contacts",
+            "count",
+            "query",
+            "limit",
+        }
+
+    def test_no_matches_returns_empty_list(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_search_contacts.return_value = []
+            result = search_contacts("zzz-no-match")
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["contacts"] == []
+
+    def test_connector_called_with_query_and_cap(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_search_contacts.return_value = []
+            search_contacts("alice")
+        mock_connector._run_cn_search_contacts.assert_called_once_with(
+            query="alice", limit=200
+        )
+
+
+class TestSearchContactsCapDetection:
+    def test_count_equals_limit_when_cap_hit(self) -> None:
+        cap_hit = [
+            {"id": f"id-{i}", "given_name": "J", "family_name": "S", "organization": ""}
+            for i in range(200)
+        ]
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_search_contacts.return_value = cap_hit
+            result = search_contacts("j")
+        assert result["count"] == 200
+        assert result["limit"] == 200
+        assert result["count"] == result["limit"]
+
+
+class TestSearchContactsConnectorRaises:
+    def test_unexpected_exception_returns_unknown_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_search_contacts.side_effect = ContactsError("boom")
+            result = search_contacts("alice")
         assert result["success"] is False
         assert result["error_type"] == "unknown"
         assert "boom" in result["error"]


### PR DESCRIPTION
Closes #12.

## Summary

Last read-only tool. Wraps `unifiedContactsMatchingPredicate_keysToFetch_error_` with `CNContact.predicateForContactsMatchingName_(query)`. Returns the same 4-field shape as `list_contacts`. Hard cap at 200 results.

```jsonc
search_contacts("john")
{
  "success": true,
  "contacts": [
    {"id": "ABCD", "given_name": "John", "family_name": "Smith", "organization": "Acme"},
    ...
  ],
  "count": 28,
  "query": "john",
  "limit": 200
}
```

## Design notes

- **Predicate offloaded to the framework** — substring, case-insensitive, matches given/family/organization names. Gap-analysis baseline: <50 ms for 28 matches over 1696 contacts. No Python iteration.
- **Empty/whitespace query → `validation_error`.** CN's predicate with `""` would silently return ALL contacts — the gate prevents this footgun.
- **`query` and `limit` echoed in response.** `query` lets the LLM disambiguate when juggling multiple searches; `limit` lets it detect truncation via `count == limit`.
- **Cap applied during serialization** (not after), so we never pay for entries we throw away. Asserted by a test that the 201st contact's selectors are never accessed.
- **Fifth `_run_cn_*` helper** added. Reuses `_require_contacts_authorization()` and the 4-field dict shape from #10.
- **Read-only** — intentionally not in `DESTRUCTIVE_OPERATIONS`.

## Test plan

- [x] `make test` — 99 tests (12 new), all pass
- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy strict clean
- [x] `make coverage` — 97.40% project-wide
- [x] `make check-all` — full gate green; client/server parity reports `check_authorization`, `get_contact`, `list_contacts`, `search_contacts`

## Out of scope (deferred)

- Phone / email / organization predicate variants → v0.2.0.
- Custom NSPredicate for compound queries → v0.2.0+.
- Pagination of search results — single-string-param contract per the issue; truncation signal via `count == limit` is sufficient.
- Real-Contacts integration test → #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)