### PR TITLE
feat: create_contact — write via CNSaveRequest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,3 +127,7 @@ strict_equality = true
 [[tool.mypy.overrides]]
 module = "Contacts"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "Foundation"
+ignore_missing_imports = true

--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -19,6 +19,7 @@ from .exceptions import (
     ContactsAppleScriptError,
     ContactsAuthorizationError,
     ContactsError,
+    ContactsNotFoundError,
     ContactsTimeoutError,
 )
 
@@ -165,6 +166,58 @@ class ContactsConnector:
             raise ContactsError(f"CN enumerate failed: {err}")
         return contacts
 
+    def _run_cn_fetch_group(self, identifier: str) -> Any | None:
+        """Fetch a CNGroup by its identifier.
+
+        Returns the CNGroup object (PyObjC-typed, not serialized) or None
+        if no group matches. Used by destructive tools that need to
+        add/remove members — they want the live object to feed into
+        CNSaveRequest.
+        """
+        from Contacts import CNGroup
+
+        pred = CNGroup.predicateForGroupsWithIdentifiers_([identifier])
+        store = self._get_store()
+        results, err = store.groupsMatchingPredicate_error_(pred, None)
+        if results is None:
+            raise ContactsError(f"CN group fetch failed: {err}")
+        if len(results) == 0:
+            return None
+        return results[0]
+
+    def _run_cn_create_contact(
+        self, fields: dict[str, Any], group_identifier: str | None
+    ) -> str:
+        """Create a contact in the default container, optionally also
+        adding it to a group, in a single atomic CNSaveRequest.
+
+        Returns the new contact's CN identifier (CN populates the
+        CNMutableContact's identifier in-place after save).
+        """
+        from Contacts import CNSaveRequest
+
+        mutable = _build_mutable_contact(fields)
+
+        group = None
+        if group_identifier is not None:
+            group = self._run_cn_fetch_group(group_identifier)
+            if group is None:
+                raise ContactsNotFoundError(
+                    f"Group not found: {group_identifier!r}"
+                )
+
+        save_req = CNSaveRequest.alloc().init()
+        save_req.addContact_toContainerWithIdentifier_(mutable, None)
+        if group is not None:
+            save_req.addMember_toGroup_(mutable, group)
+
+        store = self._get_store()
+        ok, err = store.executeSaveRequest_error_(save_req, None)
+        if not ok:
+            raise ContactsError(f"CN save failed: {err}")
+
+        return str(mutable.identifier())
+
     def _run_cn_search_contacts(
         self, query: str, limit: int
     ) -> list[dict[str, str]]:
@@ -298,6 +351,124 @@ class ContactsConnector:
             raise ContactsAuthorizationError(str(result["error"]))
 
         return bool(result["granted"])
+
+
+# ---------------------------------------------------------------------------
+# CNContact builders (module-private; inverse of serializers below)
+# ---------------------------------------------------------------------------
+
+
+def _build_mutable_contact(fields: dict[str, Any]) -> Any:
+    """Build a CNMutableContact from a dict shaped like _serialize_contact's
+    output (minus ``id``). Only sets fields the caller provided — empty
+    strings and missing keys leave the corresponding CN property unset.
+    """
+    from Contacts import (
+        CNLabeledValue,
+        CNMutableContact,
+        CNPhoneNumber,
+    )
+    from Foundation import NSDateComponents
+
+    c = CNMutableContact.alloc().init()
+
+    if v := fields.get("given_name"):
+        c.setGivenName_(v)
+    if v := fields.get("family_name"):
+        c.setFamilyName_(v)
+    if v := fields.get("middle_name"):
+        c.setMiddleName_(v)
+    if v := fields.get("name_prefix"):
+        c.setNamePrefix_(v)
+    if v := fields.get("name_suffix"):
+        c.setNameSuffix_(v)
+    if v := fields.get("nickname"):
+        c.setNickname_(v)
+    if v := fields.get("organization"):
+        c.setOrganizationName_(v)
+    if v := fields.get("job_title"):
+        c.setJobTitle_(v)
+    if v := fields.get("department"):
+        c.setDepartmentName_(v)
+
+    if phones := fields.get("phones"):
+        c.setPhoneNumbers_(
+            [
+                CNLabeledValue.labeledValueWithLabel_value_(
+                    p.get("label_raw", ""),
+                    CNPhoneNumber.phoneNumberWithStringValue_(p["value"]),
+                )
+                for p in phones
+            ]
+        )
+    if emails := fields.get("emails"):
+        c.setEmailAddresses_(
+            [
+                CNLabeledValue.labeledValueWithLabel_value_(
+                    e.get("label_raw", ""), e["value"]
+                )
+                for e in emails
+            ]
+        )
+    if urls := fields.get("urls"):
+        c.setUrlAddresses_(
+            [
+                CNLabeledValue.labeledValueWithLabel_value_(
+                    u.get("label_raw", ""), u["value"]
+                )
+                for u in urls
+            ]
+        )
+    if postal := fields.get("postal_addresses"):
+        c.setPostalAddresses_(
+            [
+                CNLabeledValue.labeledValueWithLabel_value_(
+                    a.get("label_raw", ""), _build_mutable_postal_address(a)
+                )
+                for a in postal
+            ]
+        )
+
+    if bday := fields.get("birthday"):
+        c.setBirthday_(_build_birthday_components(bday, NSDateComponents))
+
+    return c
+
+
+def _build_mutable_postal_address(a: dict[str, str]) -> Any:
+    from Contacts import CNMutablePostalAddress
+
+    addr = CNMutablePostalAddress.alloc().init()
+    if v := a.get("street"):
+        addr.setStreet_(v)
+    if v := a.get("sub_locality"):
+        addr.setSubLocality_(v)
+    if v := a.get("city"):
+        addr.setCity_(v)
+    if v := a.get("sub_administrative_area"):
+        addr.setSubAdministrativeArea_(v)
+    if v := a.get("state"):
+        addr.setState_(v)
+    if v := a.get("postal_code"):
+        addr.setPostalCode_(v)
+    if v := a.get("country"):
+        addr.setCountry_(v)
+    if v := a.get("iso_country_code"):
+        addr.setISOCountryCode_(v)
+    return addr
+
+
+def _build_birthday_components(
+    bday: dict[str, int], NSDateComponents: Any
+) -> Any:
+    dc = NSDateComponents.alloc().init()
+    if y := bday.get("year"):
+        dc.setYear_(y)
+    if m := bday.get("month"):
+        dc.setMonth_(m)
+    if d := bday.get("day"):
+        dc.setDay_(d)
+    return dc
 
 
 # ---------------------------------------------------------------------------

--- a/src/apple_contacts_mcp/exceptions.py
+++ b/src/apple_contacts_mcp/exceptions.py
@@ -23,3 +23,9 @@ class ContactsTimeoutError(ContactsError):
     """A subprocess or CN async operation exceeded its timeout."""
 
     pass
+
+
+class ContactsNotFoundError(ContactsError):
+    """A referenced CN object (contact or group) was not found."""
+
+    pass

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -8,7 +8,8 @@ from typing import Any
 from fastmcp import FastMCP
 
 from .contacts_connector import ContactsConnector
-from .exceptions import ContactsTimeoutError
+from .exceptions import ContactsNotFoundError, ContactsTimeoutError
+from .security import check_test_mode_safety
 
 logging.basicConfig(
     level=logging.INFO,
@@ -297,6 +298,182 @@ def search_contacts(query: str) -> dict[str, Any]:
         "query": query,
         "limit": _SEARCH_CONTACTS_MAX,
     }
+
+
+def _validate_create_contact_input(
+    fields: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Validate create_contact's parsed input. Returns None if OK, error
+    dict otherwise."""
+    if not (
+        (fields.get("given_name") or "").strip()
+        or (fields.get("family_name") or "").strip()
+        or (fields.get("organization") or "").strip()
+    ):
+        return _validation_error(
+            "At least one of given_name, family_name, or organization "
+            "must be set."
+        )
+
+    for i, p in enumerate(fields.get("phones") or []):
+        if not (p.get("value") or "").strip():
+            return _validation_error(f"phones[{i}].value must be non-empty")
+
+    for i, e in enumerate(fields.get("emails") or []):
+        v = (e.get("value") or "").strip()
+        if not v:
+            return _validation_error(f"emails[{i}].value must be non-empty")
+        if "@" not in v:
+            return _validation_error(f"emails[{i}].value must contain '@'")
+
+    for i, u in enumerate(fields.get("urls") or []):
+        if not (u.get("value") or "").strip():
+            return _validation_error(f"urls[{i}].value must be non-empty")
+
+    for i, a in enumerate(fields.get("postal_addresses") or []):
+        if not any(
+            (a.get(k) or "").strip()
+            for k in ("street", "city", "state", "postal_code", "country")
+        ):
+            return _validation_error(
+                f"postal_addresses[{i}] must set at least one of "
+                f"street/city/state/postal_code/country"
+            )
+
+    bday = fields.get("birthday")
+    if bday is not None:
+        m = bday.get("month")
+        d = bday.get("day")
+        y = bday.get("year")
+        if m is not None and not (1 <= m <= 12):
+            return _validation_error("birthday.month must be 1-12")
+        if d is not None and not (1 <= d <= 31):
+            return _validation_error("birthday.day must be 1-31")
+        if y is not None and y <= 0:
+            return _validation_error("birthday.year must be > 0 if set")
+
+    return None
+
+
+def _validation_error(msg: str) -> dict[str, Any]:
+    return {
+        "success": False,
+        "error": msg,
+        "error_type": "validation_error",
+    }
+
+
+@mcp.tool()
+def create_contact(
+    given_name: str = "",
+    family_name: str = "",
+    middle_name: str = "",
+    name_prefix: str = "",
+    name_suffix: str = "",
+    nickname: str = "",
+    organization: str = "",
+    job_title: str = "",
+    department: str = "",
+    phones: list[dict[str, str]] | None = None,
+    emails: list[dict[str, str]] | None = None,
+    urls: list[dict[str, str]] | None = None,
+    postal_addresses: list[dict[str, str]] | None = None,
+    birthday: dict[str, int] | None = None,
+    group_identifier: str | None = None,
+) -> dict[str, Any]:
+    """Create a new contact in the user's default container.
+
+    Pass any subset of the P1 fields. At least one of ``given_name``,
+    ``family_name``, or ``organization`` must be non-empty. Labeled-value
+    entries (phones, emails, urls, postal_addresses) carry ``label_raw``
+    (an Apple token like ``_$!<Mobile>!$_``, or any custom string) plus
+    their type-specific value field(s).
+
+    In test mode (``CONTACTS_TEST_MODE=true``), ``group_identifier`` must
+    be provided and must match ``CONTACTS_TEST_GROUP``. The new contact
+    is added to that group atomically with creation, so the test
+    harness can clean it up.
+
+    Args:
+        given_name, family_name, middle_name, name_prefix, name_suffix,
+        nickname: Name parts; default "".
+        organization, job_title, department: Org triplet; default "".
+        phones / emails / urls: Lists of ``{label_raw, value}`` dicts.
+        postal_addresses: List of ``{label_raw, street, sub_locality,
+            city, sub_administrative_area, state, postal_code, country,
+            iso_country_code}`` dicts (any subset; at least one address
+            field must be non-empty).
+        birthday: ``{year?, month?, day?}`` (any subset).
+        group_identifier: If set, the new contact is added to this group
+            in the same CNSaveRequest. Required in test mode.
+
+    Returns:
+        On success: ``{"success": True, "identifier": "...",
+        "group_id": "..."}``. ``group_id`` is omitted when
+        ``group_identifier`` was None.
+        On bad input: ``{"success": False, "error_type":
+        "validation_error", "error": ...}``.
+        On TCC denial: same shape as ``list_contacts``.
+        On test-mode safety violation: ``{"success": False,
+        "error_type": "safety_violation", "error": ...}``.
+        On group not found: ``{"success": False, "error_type":
+        "not_found", "error": ...}``.
+        On CN save failure: ``{"success": False, "error_type":
+        "unknown", "error": ...}``.
+    """
+    fields: dict[str, Any] = {
+        "given_name": given_name,
+        "family_name": family_name,
+        "middle_name": middle_name,
+        "name_prefix": name_prefix,
+        "name_suffix": name_suffix,
+        "nickname": nickname,
+        "organization": organization,
+        "job_title": job_title,
+        "department": department,
+        "phones": phones or [],
+        "emails": emails or [],
+        "urls": urls or [],
+        "postal_addresses": postal_addresses or [],
+        "birthday": birthday,
+    }
+
+    validation_err = _validate_create_contact_input(fields)
+    if validation_err is not None:
+        return validation_err
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    safety_err = check_test_mode_safety(
+        "create_contact", group=group_identifier
+    )
+    if safety_err is not None:
+        return safety_err
+
+    try:
+        identifier = connector._run_cn_create_contact(
+            fields=fields, group_identifier=group_identifier
+        )
+    except ContactsNotFoundError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_type": "not_found",
+        }
+    except Exception as exc:
+        logger.error("create_contact failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"Create failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    response: dict[str, Any] = {"success": True, "identifier": identifier}
+    if group_identifier is not None:
+        response["group_id"] = group_identifier
+    return response
 
 
 def main() -> None:

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -21,6 +21,7 @@ from apple_contacts_mcp.exceptions import (
     ContactsAppleScriptError,
     ContactsAuthorizationError,
     ContactsError,
+    ContactsNotFoundError,
     ContactsTimeoutError,
 )
 
@@ -816,3 +817,288 @@ def test_search_raises_contacts_error_when_results_is_none(
     with pytest.raises(ContactsError) as exc_info:
         connector._run_cn_search_contacts(query="x", limit=200)
     assert "boom" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_fetch_group + _run_cn_create_contact
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_contacts_for_create(
+    monkeypatch: pytest.MonkeyPatch,
+    group_results: list[Any] | None = None,
+    save_succeeds: bool = True,
+    fake_save_error: Any | None = None,
+    new_identifier: str = "NEW-ID-1234",
+) -> tuple[MagicMock, MagicMock, MagicMock, MagicMock]:
+    """Install fake Contacts + Foundation modules + a store that:
+      - groupsMatchingPredicate_error_ returns (group_results, None) (or
+        (None, error) if group_results is None to simulate error path).
+      - executeSaveRequest_error_ returns (save_succeeds, fake_save_error).
+      - CNMutableContact.alloc().init() returns a MagicMock whose
+        .identifier() returns `new_identifier` (CN populates it post-save).
+
+    Returns (CNContactStore_class, store_instance, CNMutableContact_class,
+    CNSaveRequest_instance) for assertions.
+    """
+    fake_contacts = types.ModuleType("Contacts")
+
+    cn_mutable_contact_class = MagicMock(name="CNMutableContact")
+    mutable_instance = MagicMock(name="mutable_contact_instance")
+    mutable_instance.identifier.return_value = new_identifier
+    cn_mutable_contact_class.alloc.return_value.init.return_value = mutable_instance
+    fake_contacts.CNMutableContact = cn_mutable_contact_class  # type: ignore[attr-defined]
+
+    cn_postal_class = MagicMock(name="CNMutablePostalAddress")
+    postal_instance = MagicMock(name="postal_instance")
+    cn_postal_class.alloc.return_value.init.return_value = postal_instance
+    fake_contacts.CNMutablePostalAddress = cn_postal_class  # type: ignore[attr-defined]
+
+    cn_phone_class = MagicMock(name="CNPhoneNumber")
+    cn_phone_class.phoneNumberWithStringValue_.side_effect = (
+        lambda v: f"PhoneNumber({v})"
+    )
+    fake_contacts.CNPhoneNumber = cn_phone_class  # type: ignore[attr-defined]
+
+    cn_labeled_class = MagicMock(name="CNLabeledValue")
+    cn_labeled_class.labeledValueWithLabel_value_.side_effect = (
+        lambda lbl, val: ("labeled", lbl, val)
+    )
+    fake_contacts.CNLabeledValue = cn_labeled_class  # type: ignore[attr-defined]
+
+    cn_save_request_class = MagicMock(name="CNSaveRequest")
+    save_request_instance = MagicMock(name="save_request_instance")
+    cn_save_request_class.alloc.return_value.init.return_value = save_request_instance
+    fake_contacts.CNSaveRequest = cn_save_request_class  # type: ignore[attr-defined]
+
+    cn_group_class = MagicMock(name="CNGroup")
+    cn_group_class.predicateForGroupsWithIdentifiers_.return_value = "GROUP_PRED"
+    fake_contacts.CNGroup = cn_group_class  # type: ignore[attr-defined]
+
+    cn_store_class = MagicMock(name="CNContactStore")
+    store_instance = MagicMock(name="store_instance")
+    if group_results is None:
+        store_instance.groupsMatchingPredicate_error_.return_value = (
+            None,
+            MagicMock(name="NSError(group_fetch)"),
+        )
+    else:
+        store_instance.groupsMatchingPredicate_error_.return_value = (
+            group_results,
+            None,
+        )
+    store_instance.executeSaveRequest_error_.return_value = (
+        save_succeeds,
+        fake_save_error,
+    )
+    cn_store_class.alloc.return_value.init.return_value = store_instance
+    fake_contacts.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "Contacts", fake_contacts)
+
+    fake_foundation = types.ModuleType("Foundation")
+    nsdc_class = MagicMock(name="NSDateComponents")
+    nsdc_instance = MagicMock(name="nsdc_instance")
+    nsdc_class.alloc.return_value.init.return_value = nsdc_instance
+    fake_foundation.NSDateComponents = nsdc_class  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "Foundation", fake_foundation)
+
+    return cn_store_class, store_instance, cn_mutable_contact_class, save_request_instance
+
+
+# ----- _run_cn_fetch_group ----------------------------------------------------
+
+
+def test_fetch_group_returns_group_when_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_group = MagicMock(name="CNGroup_instance")
+    _install_fake_contacts_for_create(monkeypatch, group_results=[fake_group])
+    connector = ContactsConnector()
+    assert connector._run_cn_fetch_group("group-id") is fake_group
+
+
+def test_fetch_group_returns_none_when_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_contacts_for_create(monkeypatch, group_results=[])
+    connector = ContactsConnector()
+    assert connector._run_cn_fetch_group("missing") is None
+
+
+def test_fetch_group_raises_on_cn_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_contacts_for_create(monkeypatch, group_results=None)
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError):
+        connector._run_cn_fetch_group("any")
+
+
+# ----- _run_cn_create_contact -------------------------------------------------
+
+
+def test_create_contact_minimal_returns_new_identifier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, store, _, save_req = _install_fake_contacts_for_create(
+        monkeypatch, new_identifier="NEW-ID-1"
+    )
+    connector = ContactsConnector()
+    result = connector._run_cn_create_contact(
+        fields={"given_name": "Alice"}, group_identifier=None
+    )
+    assert result == "NEW-ID-1"
+    save_req.addContact_toContainerWithIdentifier_.assert_called_once()
+    args, _ = save_req.addContact_toContainerWithIdentifier_.call_args
+    assert args[1] is None  # default container
+    save_req.addMember_toGroup_.assert_not_called()
+    store.executeSaveRequest_error_.assert_called_once()
+
+
+def test_create_contact_sets_all_simple_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, mutable_class, _ = _install_fake_contacts_for_create(monkeypatch)
+    connector = ContactsConnector()
+    connector._run_cn_create_contact(
+        fields={
+            "given_name": "G",
+            "family_name": "F",
+            "middle_name": "M",
+            "name_prefix": "P",
+            "name_suffix": "S",
+            "nickname": "N",
+            "organization": "O",
+            "job_title": "J",
+            "department": "D",
+        },
+        group_identifier=None,
+    )
+    mutable = mutable_class.alloc.return_value.init.return_value
+    mutable.setGivenName_.assert_called_once_with("G")
+    mutable.setFamilyName_.assert_called_once_with("F")
+    mutable.setMiddleName_.assert_called_once_with("M")
+    mutable.setNamePrefix_.assert_called_once_with("P")
+    mutable.setNameSuffix_.assert_called_once_with("S")
+    mutable.setNickname_.assert_called_once_with("N")
+    mutable.setOrganizationName_.assert_called_once_with("O")
+    mutable.setJobTitle_.assert_called_once_with("J")
+    mutable.setDepartmentName_.assert_called_once_with("D")
+
+
+def test_create_contact_skips_setters_for_empty_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, mutable_class, _ = _install_fake_contacts_for_create(monkeypatch)
+    connector = ContactsConnector()
+    connector._run_cn_create_contact(
+        fields={"given_name": "Alice"}, group_identifier=None
+    )
+    mutable = mutable_class.alloc.return_value.init.return_value
+    mutable.setFamilyName_.assert_not_called()
+    mutable.setOrganizationName_.assert_not_called()
+    mutable.setBirthday_.assert_not_called()
+
+
+def test_create_contact_with_phones_emails_urls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, mutable_class, _ = _install_fake_contacts_for_create(monkeypatch)
+    connector = ContactsConnector()
+    connector._run_cn_create_contact(
+        fields={
+            "given_name": "Alice",
+            "phones": [{"label_raw": "_$!<Mobile>!$_", "value": "+1 555-1212"}],
+            "emails": [{"label_raw": "_$!<Home>!$_", "value": "alice@example.com"}],
+            "urls": [{"label_raw": "", "value": "https://example.com"}],
+        },
+        group_identifier=None,
+    )
+    mutable = mutable_class.alloc.return_value.init.return_value
+    mutable.setPhoneNumbers_.assert_called_once()
+    mutable.setEmailAddresses_.assert_called_once()
+    mutable.setUrlAddresses_.assert_called_once()
+
+
+def test_create_contact_with_postal_address(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, mutable_class, _ = _install_fake_contacts_for_create(monkeypatch)
+    connector = ContactsConnector()
+    connector._run_cn_create_contact(
+        fields={
+            "given_name": "Alice",
+            "postal_addresses": [
+                {
+                    "label_raw": "_$!<Home>!$_",
+                    "street": "1 Loop", "city": "Cupertino",
+                    "state": "CA", "postal_code": "95014",
+                    "country": "USA", "iso_country_code": "us",
+                }
+            ],
+        },
+        group_identifier=None,
+    )
+    mutable = mutable_class.alloc.return_value.init.return_value
+    mutable.setPostalAddresses_.assert_called_once()
+
+
+def test_create_contact_with_birthday(monkeypatch: pytest.MonkeyPatch) -> None:
+    _, _, mutable_class, _ = _install_fake_contacts_for_create(monkeypatch)
+    connector = ContactsConnector()
+    connector._run_cn_create_contact(
+        fields={
+            "given_name": "Alice",
+            "birthday": {"year": 1990, "month": 5, "day": 15},
+        },
+        group_identifier=None,
+    )
+    mutable = mutable_class.alloc.return_value.init.return_value
+    mutable.setBirthday_.assert_called_once()
+
+
+def test_create_contact_with_group_attaches_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_group = MagicMock(name="CNGroup_instance")
+    _, store, _, save_req = _install_fake_contacts_for_create(
+        monkeypatch, group_results=[fake_group]
+    )
+    connector = ContactsConnector()
+    result = connector._run_cn_create_contact(
+        fields={"given_name": "Alice"}, group_identifier="MCP-Test-id"
+    )
+    assert result  # any identifier
+    save_req.addContact_toContainerWithIdentifier_.assert_called_once()
+    save_req.addMember_toGroup_.assert_called_once()
+    args, _ = save_req.addMember_toGroup_.call_args
+    assert args[1] is fake_group
+    store.executeSaveRequest_error_.assert_called_once()
+
+
+def test_create_contact_raises_not_found_when_group_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, store, _, save_req = _install_fake_contacts_for_create(
+        monkeypatch, group_results=[]
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsNotFoundError):
+        connector._run_cn_create_contact(
+            fields={"given_name": "Alice"}, group_identifier="missing"
+        )
+    save_req.addContact_toContainerWithIdentifier_.assert_not_called()
+    store.executeSaveRequest_error_.assert_not_called()
+
+
+def test_create_contact_raises_when_save_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_save_error = MagicMock(name="NSError(save)")
+    fake_save_error.__str__.return_value = "save boom"
+    _install_fake_contacts_for_create(
+        monkeypatch, save_succeeds=False, fake_save_error=fake_save_error
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_create_contact(
+            fields={"given_name": "Alice"}, group_identifier=None
+        )
+    assert "save boom" in str(exc_info.value)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -7,9 +7,14 @@ from unittest.mock import patch
 
 import pytest
 
-from apple_contacts_mcp.exceptions import ContactsError, ContactsTimeoutError
+from apple_contacts_mcp.exceptions import (
+    ContactsError,
+    ContactsNotFoundError,
+    ContactsTimeoutError,
+)
 from apple_contacts_mcp.server import (
     check_authorization,
+    create_contact,
     get_contact,
     list_contacts,
     search_contacts,
@@ -421,3 +426,208 @@ class TestSearchContactsConnectorRaises:
         assert result["success"] is False
         assert result["error_type"] == "unknown"
         assert "boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# create_contact
+# ---------------------------------------------------------------------------
+
+
+class TestCreateContactValidation:
+    def test_all_empty_names_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = create_contact()
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_authorization_status.assert_not_called()
+        mock_connector._run_cn_create_contact.assert_not_called()
+
+    def test_whitespace_only_names_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = create_contact(given_name="   ", family_name="\t\n")
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_create_contact.assert_not_called()
+
+    def test_email_without_at_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = create_contact(
+                given_name="Alice",
+                emails=[{"label_raw": "", "value": "no-at-sign"}],
+            )
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        assert "@" in result["error"]
+        mock_connector._run_cn_create_contact.assert_not_called()
+
+    def test_phone_with_empty_value_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = create_contact(
+                given_name="Alice", phones=[{"label_raw": "", "value": ""}]
+            )
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_create_contact.assert_not_called()
+
+    def test_url_with_empty_value_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector"):
+            result = create_contact(
+                given_name="Alice", urls=[{"label_raw": "", "value": ""}]
+            )
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+
+    def test_postal_address_all_empty_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector"):
+            result = create_contact(
+                given_name="Alice",
+                postal_addresses=[{"label_raw": "_$!<Home>!$_"}],
+            )
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+
+    @pytest.mark.parametrize(
+        "bday",
+        [
+            {"month": 0, "day": 1},
+            {"month": 13, "day": 1},
+            {"month": 5, "day": 0},
+            {"month": 5, "day": 32},
+            {"year": -1, "month": 5, "day": 15},
+        ],
+    )
+    def test_invalid_birthday_returns_validation_error(
+        self, bday: dict[str, int]
+    ) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = create_contact(given_name="Alice", birthday=bday)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_create_contact.assert_not_called()
+
+
+class TestCreateContactAuthFlow:
+    def test_auth_denied_passthrough_skips_save(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "denied"
+            result = create_contact(given_name="Alice")
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        mock_connector._run_cn_create_contact.assert_not_called()
+
+
+class TestCreateContactTestModeSafety:
+    def test_test_mode_without_group_arg_blocked(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        from apple_contacts_mcp.security import _get_test_group_identifiers
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = create_contact(given_name="Alice")
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        mock_connector._run_cn_create_contact.assert_not_called()
+
+    def test_test_mode_with_matching_group_proceeds(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        from apple_contacts_mcp.security import _get_test_group_identifiers
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_contact.return_value = "NEW-ID"
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                # Name matching falls back when subprocess fails — name "MCP-Test" matches.
+                result = create_contact(
+                    given_name="Alice", group_identifier="MCP-Test"
+                )
+        assert result["success"] is True
+        assert result["identifier"] == "NEW-ID"
+        assert result["group_id"] == "MCP-Test"
+
+
+class TestCreateContactHappyPath:
+    def test_minimal_returns_identifier_no_group(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_contact.return_value = "NEW-ID-1"
+            result = create_contact(given_name="Alice")
+        assert result == {"success": True, "identifier": "NEW-ID-1"}
+        mock_connector._run_cn_create_contact.assert_called_once()
+        kwargs = mock_connector._run_cn_create_contact.call_args.kwargs
+        assert kwargs["group_identifier"] is None
+        assert kwargs["fields"]["given_name"] == "Alice"
+
+    def test_with_group_includes_group_id_in_response(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_contact.return_value = "NEW-ID-2"
+            result = create_contact(
+                given_name="Alice", group_identifier="GROUP-XYZ"
+            )
+        assert result == {
+            "success": True,
+            "identifier": "NEW-ID-2",
+            "group_id": "GROUP-XYZ",
+        }
+
+    def test_full_field_set_passes_through_to_connector(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_contact.return_value = "NEW"
+            create_contact(
+                given_name="Alice",
+                family_name="Adams",
+                organization="Acme",
+                phones=[{"label_raw": "_$!<Mobile>!$_", "value": "+1 555-1212"}],
+                emails=[{"label_raw": "", "value": "alice@example.com"}],
+                urls=[{"label_raw": "", "value": "https://example.com"}],
+                postal_addresses=[
+                    {
+                        "label_raw": "_$!<Home>!$_",
+                        "city": "Cupertino",
+                    }
+                ],
+                birthday={"year": 1990, "month": 5, "day": 15},
+            )
+        kwargs = mock_connector._run_cn_create_contact.call_args.kwargs
+        fields = kwargs["fields"]
+        assert fields["given_name"] == "Alice"
+        assert fields["family_name"] == "Adams"
+        assert fields["organization"] == "Acme"
+        assert len(fields["phones"]) == 1
+        assert fields["birthday"] == {"year": 1990, "month": 5, "day": 15}
+
+
+class TestCreateContactNotFound:
+    def test_group_not_found_maps_to_not_found(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_contact.side_effect = (
+                ContactsNotFoundError("Group not found: 'BAD-GROUP'")
+            )
+            result = create_contact(
+                given_name="Alice", group_identifier="BAD-GROUP"
+            )
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+        assert "BAD-GROUP" in result["error"]
+
+
+class TestCreateContactSaveFailure:
+    def test_cn_save_error_returns_unknown(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_contact.side_effect = ContactsError(
+                "save boom"
+            )
+            result = create_contact(given_name="Alice")
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "save boom" in result["error"]


### PR DESCRIPTION
Closes #13.

## Summary

First destructive tool. Wraps `CNMutableContact` + `CNSaveRequest.addContact:toContainerWithIdentifier:` (default container) plus optional `addMember:toGroup:` in a single atomic save. Returns the new contact's CN identifier.

```jsonc
create_contact(given_name="Alice", family_name="Adams")
{"success": true, "identifier": "ABCD-1234-..."}

create_contact(given_name="Alice", group_identifier="GROUP-XYZ")
{"success": true, "identifier": "ABCD-1234-...", "group_id": "GROUP-XYZ"}
```

## Design notes

- **Test-mode safety wired up.** `check_test_mode_safety` from #6 was inert until now. `create_contact` accepts an optional `group_identifier` param — in test mode it must match `CONTACTS_TEST_GROUP`, and the new contact is added to that group atomically with creation so the test harness can clean up. Outside test mode, `group_identifier` is purely optional.
- **Reverse label mapping deferred to v0.2.0 (#18).** Callers pass `label_raw` directly (Apple tokens like `_$!<Mobile>!$_` round-trippable from `get_contact`'s output, or any custom string).
- **Rate-limit + audit-log call sites deferred to v0.4.0** per playbook §4. Two follow-up issues will be opened to track wiring them in once their helpers exist.
- **Two new `_run_cn_*` family members** (`_run_cn_fetch_group`, `_run_cn_create_contact`) plus three private builders (`_build_mutable_contact`, `_build_mutable_postal_address`, `_build_birthday_components`) — exact inverse of the `get_contact` serializers from #11.
- **New `ContactsNotFoundError` exception** for the group-not-found case; reused by #14.
- **Validation gate**: requires at least one of given_name/family_name/organization; emails need `@`; postal addresses need at least one geographic field; birthday month/day in valid range.

## Test plan

- [x] `make test` — 130 tests (31 new), all pass
- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy strict clean (added `Foundation` mypy override alongside existing `Contacts`)
- [x] `make coverage` — 97.60% project-wide; server.py 99%, security.py 100%
- [x] `make check-all` — full gate green; client/server parity reports `check_authorization`, `create_contact`, `get_contact`, `list_contacts`, `search_contacts`

## Out of scope (deferred)

- Reverse label mapping → v0.2.0 (#18).
- Container choice arg → v0.2.0+.
- Contact image / photo → future MCP-resource tool.
- Confirmation UX → v0.4.0 (#24).
- Real `sanitize_input` → v0.4.0 (existing stub passes through).
- Rate-limit + audit-log call sites → v0.4.0 (separate follow-up issues to be opened post-merge).
- Real-Contacts integration test → #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)