### PR TITLE
feat: update_contact + delete_contact

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,3 +131,20 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "Foundation"
 ignore_missing_imports = true
+
+[tool.pyright]
+include = ["src", "tests"]
+exclude = ["**/node_modules", "**/__pycache__", ".venv", "venv"]
+pythonVersion = "3.10"
+pythonPlatform = "Darwin"
+typeCheckingMode = "basic"
+reportMissingImports = true
+reportMissingTypeStubs = false
+# PyObjC populates module attributes (e.g. `Contacts.CNGroup`,
+# `Foundation.NSDateComponents`) dynamically at runtime via
+# `objc.loadBundleVariables`, so they look like missing attributes to a
+# static analyzer. Mypy already silences this via
+# `[[tool.mypy.overrides]]` below; mirror for Pylance/pyright here.
+reportAttributeAccessIssue = "none"
+venvPath = "."
+venv = ".venv"

--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -218,6 +218,95 @@ class ContactsConnector:
 
         return str(mutable.identifier())
 
+    def _run_cn_update_contact(
+        self, identifier: str, fields: dict[str, Any]
+    ) -> str:
+        """Apply partial field updates to an existing contact and save.
+
+        Fetches the contact with the full P1 key set (so any subset of
+        fields is writable without CNPropertyNotFetchedException), takes
+        a mutable copy, applies only the keys present in ``fields``, and
+        saves via CNSaveRequest.updateContact_.
+
+        Returns the identifier (echoes input) for response symmetry.
+        """
+        from Contacts import (
+            CNContactBirthdayKey,
+            CNContactDepartmentNameKey,
+            CNContactEmailAddressesKey,
+            CNContactFamilyNameKey,
+            CNContactGivenNameKey,
+            CNContactJobTitleKey,
+            CNContactMiddleNameKey,
+            CNContactNamePrefixKey,
+            CNContactNameSuffixKey,
+            CNContactNicknameKey,
+            CNContactOrganizationNameKey,
+            CNContactPhoneNumbersKey,
+            CNContactPostalAddressesKey,
+            CNContactUrlAddressesKey,
+            CNSaveRequest,
+        )
+
+        keys = [
+            CNContactGivenNameKey,
+            CNContactFamilyNameKey,
+            CNContactMiddleNameKey,
+            CNContactNamePrefixKey,
+            CNContactNameSuffixKey,
+            CNContactNicknameKey,
+            CNContactOrganizationNameKey,
+            CNContactJobTitleKey,
+            CNContactDepartmentNameKey,
+            CNContactPhoneNumbersKey,
+            CNContactEmailAddressesKey,
+            CNContactPostalAddressesKey,
+            CNContactUrlAddressesKey,
+            CNContactBirthdayKey,
+        ]
+
+        store = self._get_store()
+        contact, _err = store.unifiedContactWithIdentifier_keysToFetch_error_(
+            identifier, keys, None
+        )
+        if contact is None:
+            raise ContactsNotFoundError(
+                f"Contact not found: {identifier!r}"
+            )
+
+        mutable = contact.mutableCopy()
+        _apply_update_fields(mutable, fields)
+
+        save_req = CNSaveRequest.alloc().init()
+        save_req.updateContact_(mutable)
+        ok, err = store.executeSaveRequest_error_(save_req, None)
+        if not ok:
+            raise ContactsError(f"CN update failed: {err}")
+
+        return identifier
+
+    def _run_cn_delete_contact(self, identifier: str) -> str:
+        """Delete an existing contact. Returns the identifier (echo)."""
+        from Contacts import CNContactIdentifierKey, CNSaveRequest
+
+        store = self._get_store()
+        contact, _err = store.unifiedContactWithIdentifier_keysToFetch_error_(
+            identifier, [CNContactIdentifierKey], None
+        )
+        if contact is None:
+            raise ContactsNotFoundError(
+                f"Contact not found: {identifier!r}"
+            )
+
+        mutable = contact.mutableCopy()
+        save_req = CNSaveRequest.alloc().init()
+        save_req.deleteContact_(mutable)
+        ok, err = store.executeSaveRequest_error_(save_req, None)
+        if not ok:
+            raise ContactsError(f"CN delete failed: {err}")
+
+        return identifier
+
     def _run_cn_search_contacts(
         self, query: str, limit: int
     ) -> list[dict[str, str]]:
@@ -469,6 +558,80 @@ def _build_birthday_components(
     if d := bday.get("day"):
         dc.setDay_(d)
     return dc
+
+
+_UPDATE_SIMPLE_SETTERS: list[tuple[str, str]] = [
+    ("given_name", "setGivenName_"),
+    ("family_name", "setFamilyName_"),
+    ("middle_name", "setMiddleName_"),
+    ("name_prefix", "setNamePrefix_"),
+    ("name_suffix", "setNameSuffix_"),
+    ("nickname", "setNickname_"),
+    ("organization", "setOrganizationName_"),
+    ("job_title", "setJobTitle_"),
+    ("department", "setDepartmentName_"),
+]
+
+
+def _apply_update_fields(mutable: Any, fields: dict[str, Any]) -> None:
+    """Apply only the fields present in ``fields`` to a CNMutableContact.
+
+    Uses **presence** check (``"key" in fields``), not truthy: passing
+    ``given_name=""`` explicitly clears the field; omitting ``given_name``
+    leaves it untouched. Multi-valued fields (phones / emails / urls /
+    postal_addresses) follow REST-PUT semantics — the supplied list
+    replaces the existing list entirely.
+    """
+    from Contacts import CNLabeledValue, CNPhoneNumber
+
+    for key, setter in _UPDATE_SIMPLE_SETTERS:
+        if key in fields:
+            getattr(mutable, setter)(fields[key])
+
+    if "phones" in fields:
+        mutable.setPhoneNumbers_(
+            [
+                CNLabeledValue.labeledValueWithLabel_value_(
+                    p.get("label_raw", ""),
+                    CNPhoneNumber.phoneNumberWithStringValue_(p["value"]),
+                )
+                for p in fields["phones"]
+            ]
+        )
+    if "emails" in fields:
+        mutable.setEmailAddresses_(
+            [
+                CNLabeledValue.labeledValueWithLabel_value_(
+                    e.get("label_raw", ""), e["value"]
+                )
+                for e in fields["emails"]
+            ]
+        )
+    if "urls" in fields:
+        mutable.setUrlAddresses_(
+            [
+                CNLabeledValue.labeledValueWithLabel_value_(
+                    u.get("label_raw", ""), u["value"]
+                )
+                for u in fields["urls"]
+            ]
+        )
+    if "postal_addresses" in fields:
+        mutable.setPostalAddresses_(
+            [
+                CNLabeledValue.labeledValueWithLabel_value_(
+                    a.get("label_raw", ""), _build_mutable_postal_address(a)
+                )
+                for a in fields["postal_addresses"]
+            ]
+        )
+
+    if "birthday" in fields:
+        from Foundation import NSDateComponents
+
+        mutable.setBirthday_(
+            _build_birthday_components(fields["birthday"], NSDateComponents)
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/apple_contacts_mcp/security.py
+++ b/src/apple_contacts_mcp/security.py
@@ -150,6 +150,26 @@ def _get_test_group_identifiers(test_group_name: str) -> frozenset[str]:
     return frozenset(identifiers)
 
 
+def require_test_mode_for(operation: str) -> dict[str, Any] | None:
+    """Refuses an operation when CONTACTS_TEST_MODE is not 'true'.
+
+    Use for destructive ops that lack a confirmation UX — they are
+    only safe to expose in test mode until v0.4.0 ships the
+    confirmation flow (#24).
+
+    Returns None when test mode is enabled; otherwise a structured
+    safety_violation error dict.
+    """
+    if not _is_test_mode_enabled():
+        return _safety_error(
+            operation,
+            f"{operation} is only available with CONTACTS_TEST_MODE=true. "
+            f"The full destructive UX (with confirmation prompts) ships "
+            f"in v0.4.0 (#24).",
+        )
+    return None
+
+
 def _safety_error(operation: str, message: str) -> dict[str, Any]:
     """Build the standard safety-violation error dict."""
     logger.warning("Safety violation in %s: %s", operation, message)

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -9,7 +9,7 @@ from fastmcp import FastMCP
 
 from .contacts_connector import ContactsConnector
 from .exceptions import ContactsNotFoundError, ContactsTimeoutError
-from .security import check_test_mode_safety
+from .security import check_test_mode_safety, require_test_mode_for
 
 logging.basicConfig(
     level=logging.INFO,
@@ -474,6 +474,232 @@ def create_contact(
     if group_identifier is not None:
         response["group_id"] = group_identifier
     return response
+
+
+def _validate_update_contact_input(
+    identifier: str, fields: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Validate update_contact's parsed input. Returns None if OK, error
+    dict otherwise."""
+    if not identifier or not identifier.strip():
+        return _validation_error("identifier must be a non-empty string")
+
+    if len(fields) == 0:
+        return _validation_error(
+            "At least one field must be supplied to update."
+        )
+
+    for i, p in enumerate(fields.get("phones") or []):
+        if not (p.get("value") or "").strip():
+            return _validation_error(f"phones[{i}].value must be non-empty")
+
+    for i, e in enumerate(fields.get("emails") or []):
+        v = (e.get("value") or "").strip()
+        if not v:
+            return _validation_error(f"emails[{i}].value must be non-empty")
+        if "@" not in v:
+            return _validation_error(f"emails[{i}].value must contain '@'")
+
+    for i, u in enumerate(fields.get("urls") or []):
+        if not (u.get("value") or "").strip():
+            return _validation_error(f"urls[{i}].value must be non-empty")
+
+    for i, a in enumerate(fields.get("postal_addresses") or []):
+        if not any(
+            (a.get(k) or "").strip()
+            for k in ("street", "city", "state", "postal_code", "country")
+        ):
+            return _validation_error(
+                f"postal_addresses[{i}] must set at least one of "
+                f"street/city/state/postal_code/country"
+            )
+
+    bday = fields.get("birthday")
+    if bday is not None:
+        m = bday.get("month")
+        d = bday.get("day")
+        y = bday.get("year")
+        if m is not None and not (1 <= m <= 12):
+            return _validation_error("birthday.month must be 1-12")
+        if d is not None and not (1 <= d <= 31):
+            return _validation_error("birthday.day must be 1-31")
+        if y is not None and y <= 0:
+            return _validation_error("birthday.year must be > 0 if set")
+
+    return None
+
+
+@mcp.tool()
+def update_contact(
+    identifier: str,
+    given_name: str | None = None,
+    family_name: str | None = None,
+    middle_name: str | None = None,
+    name_prefix: str | None = None,
+    name_suffix: str | None = None,
+    nickname: str | None = None,
+    organization: str | None = None,
+    job_title: str | None = None,
+    department: str | None = None,
+    phones: list[dict[str, str]] | None = None,
+    emails: list[dict[str, str]] | None = None,
+    urls: list[dict[str, str]] | None = None,
+    postal_addresses: list[dict[str, str]] | None = None,
+    birthday: dict[str, int] | None = None,
+    group_identifier: str | None = None,
+) -> dict[str, Any]:
+    """Update an existing contact by identifier with partial-field semantics.
+
+    Every field defaults to ``None`` meaning "don't touch". To explicitly
+    clear a string field, pass ``""``. To replace a multi-valued list
+    (phones / emails / urls / postal_addresses), pass the new list — the
+    existing list is replaced entirely (REST-PUT semantics, not append).
+    Pass ``[]`` to clear all entries of a list. At least one field must
+    be supplied.
+
+    In test mode (``CONTACTS_TEST_MODE=true``), ``group_identifier``
+    must match ``CONTACTS_TEST_GROUP``. The connector does not consult
+    ``group_identifier`` — it's only used for the test-mode safety
+    assertion.
+
+    Args:
+        identifier: The contact's CN identifier.
+        ...all P1 fields (None = don't touch; "" = clear)...
+        group_identifier: Test-mode safety assertion. Required in test
+            mode. Ignored otherwise.
+
+    Returns:
+        On success: ``{"success": True, "identifier": identifier}``.
+        Use ``get_contact(identifier)`` to read back the updated record.
+        On bad input: ``{"success": False, "error_type":
+        "validation_error", ...}``.
+        On TCC denial: same shape as ``list_contacts``.
+        On safety violation: ``{"success": False, "error_type":
+        "safety_violation", ...}``.
+        On contact not found: ``{"success": False, "error_type":
+        "not_found", ...}``.
+        On CN save failure: ``{"success": False, "error_type":
+        "unknown", ...}``.
+    """
+    fields: dict[str, Any] = {}
+    for key, value in (
+        ("given_name", given_name),
+        ("family_name", family_name),
+        ("middle_name", middle_name),
+        ("name_prefix", name_prefix),
+        ("name_suffix", name_suffix),
+        ("nickname", nickname),
+        ("organization", organization),
+        ("job_title", job_title),
+        ("department", department),
+        ("phones", phones),
+        ("emails", emails),
+        ("urls", urls),
+        ("postal_addresses", postal_addresses),
+        ("birthday", birthday),
+    ):
+        if value is not None:
+            fields[key] = value
+
+    validation_err = _validate_update_contact_input(identifier, fields)
+    if validation_err is not None:
+        return validation_err
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    safety_err = check_test_mode_safety(
+        "update_contact", group=group_identifier
+    )
+    if safety_err is not None:
+        return safety_err
+
+    try:
+        connector._run_cn_update_contact(identifier=identifier, fields=fields)
+    except ContactsNotFoundError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_type": "not_found",
+        }
+    except Exception as exc:
+        logger.error("update_contact failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"Update failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    return {"success": True, "identifier": identifier}
+
+
+@mcp.tool()
+def delete_contact(
+    identifier: str,
+    group_identifier: str | None = None,
+) -> dict[str, Any]:
+    """Delete an existing contact by identifier.
+
+    **v0.1.0 only allows delete in test mode** — the full destructive
+    UX (with confirmation prompts) ships in v0.4.0 (#24). Outside test
+    mode this returns a safety_violation error.
+
+    In test mode (``CONTACTS_TEST_MODE=true``), ``group_identifier``
+    must match ``CONTACTS_TEST_GROUP`` to ensure the deleted contact
+    is one the test harness created.
+
+    Args:
+        identifier: The contact's CN identifier.
+        group_identifier: Test-mode safety assertion. Required in test
+            mode (no other use).
+
+    Returns:
+        On success: ``{"success": True, "identifier": identifier}``.
+        On bad input: ``{"success": False, "error_type":
+        "validation_error", ...}``.
+        On test mode off: ``{"success": False, "error_type":
+        "safety_violation", ...}``.
+        On TCC denial: same shape as ``list_contacts``.
+        On contact not found: ``{"success": False, "error_type":
+        "not_found", ...}``.
+        On CN save failure: ``{"success": False, "error_type":
+        "unknown", ...}``.
+    """
+    if not identifier or not identifier.strip():
+        return _validation_error("identifier must be a non-empty string")
+
+    require_err = require_test_mode_for("delete_contact")
+    if require_err is not None:
+        return require_err
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    safety_err = check_test_mode_safety(
+        "delete_contact", group=group_identifier
+    )
+    if safety_err is not None:
+        return safety_err
+
+    try:
+        connector._run_cn_delete_contact(identifier=identifier)
+    except ContactsNotFoundError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_type": "not_found",
+        }
+    except Exception as exc:
+        logger.error("delete_contact failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"Delete failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    return {"success": True, "identifier": identifier}
 
 
 def main() -> None:

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -1102,3 +1102,256 @@ def test_create_contact_raises_when_save_fails(
             fields={"given_name": "Alice"}, group_identifier=None
         )
     assert "save boom" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_update_contact + _run_cn_delete_contact
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_contacts_for_modify(
+    monkeypatch: pytest.MonkeyPatch,
+    fetched_contact: MagicMock | None,
+    save_succeeds: bool = True,
+    fake_save_error: Any | None = None,
+) -> tuple[MagicMock, MagicMock, MagicMock, MagicMock]:
+    """Install a fake `Contacts` + `Foundation` set for update/delete tests.
+
+    The store's unifiedContactWithIdentifier_keysToFetch_error_ returns
+    (fetched_contact, None) — pass None to simulate not-found.
+    The fetched_contact (if non-None) needs a .mutableCopy() that returns
+    a fresh MagicMock.
+    Returns (store_instance, mutable_instance, save_request_instance,
+    cn_save_request_class).
+    """
+    fake_contacts = types.ModuleType("Contacts")
+    for k in (
+        "CNContactGivenNameKey",
+        "CNContactFamilyNameKey",
+        "CNContactMiddleNameKey",
+        "CNContactNamePrefixKey",
+        "CNContactNameSuffixKey",
+        "CNContactNicknameKey",
+        "CNContactOrganizationNameKey",
+        "CNContactJobTitleKey",
+        "CNContactDepartmentNameKey",
+        "CNContactPhoneNumbersKey",
+        "CNContactEmailAddressesKey",
+        "CNContactPostalAddressesKey",
+        "CNContactUrlAddressesKey",
+        "CNContactBirthdayKey",
+        "CNContactIdentifierKey",
+    ):
+        setattr(fake_contacts, k, k)
+
+    cn_phone_class = MagicMock(name="CNPhoneNumber")
+    cn_phone_class.phoneNumberWithStringValue_.side_effect = (
+        lambda v: f"PhoneNumber({v})"
+    )
+    fake_contacts.CNPhoneNumber = cn_phone_class  # type: ignore[attr-defined]
+
+    cn_postal_class = MagicMock(name="CNMutablePostalAddress")
+    cn_postal_class.alloc.return_value.init.return_value = MagicMock(
+        name="postal_instance"
+    )
+    fake_contacts.CNMutablePostalAddress = cn_postal_class  # type: ignore[attr-defined]
+
+    cn_labeled_class = MagicMock(name="CNLabeledValue")
+    cn_labeled_class.labeledValueWithLabel_value_.side_effect = (
+        lambda lbl, val: ("labeled", lbl, val)
+    )
+    fake_contacts.CNLabeledValue = cn_labeled_class  # type: ignore[attr-defined]
+
+    cn_save_request_class = MagicMock(name="CNSaveRequest")
+    save_request_instance = MagicMock(name="save_request_instance")
+    cn_save_request_class.alloc.return_value.init.return_value = save_request_instance
+    fake_contacts.CNSaveRequest = cn_save_request_class  # type: ignore[attr-defined]
+
+    cn_store_class = MagicMock(name="CNContactStore")
+    store_instance = MagicMock(name="store_instance")
+    if fetched_contact is None:
+        store_instance.unifiedContactWithIdentifier_keysToFetch_error_.return_value = (
+            None,
+            MagicMock(name="NSError(not_found)"),
+        )
+        mutable_instance = MagicMock(name="mutable_unused")
+    else:
+        store_instance.unifiedContactWithIdentifier_keysToFetch_error_.return_value = (
+            fetched_contact,
+            None,
+        )
+        mutable_instance = MagicMock(name="mutable_instance")
+        fetched_contact.mutableCopy.return_value = mutable_instance
+    store_instance.executeSaveRequest_error_.return_value = (
+        save_succeeds,
+        fake_save_error,
+    )
+    cn_store_class.alloc.return_value.init.return_value = store_instance
+    fake_contacts.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "Contacts", fake_contacts)
+
+    fake_foundation = types.ModuleType("Foundation")
+    nsdc_class = MagicMock(name="NSDateComponents")
+    nsdc_class.alloc.return_value.init.return_value = MagicMock(name="nsdc_instance")
+    fake_foundation.NSDateComponents = nsdc_class  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "Foundation", fake_foundation)
+
+    return store_instance, mutable_instance, save_request_instance, cn_save_request_class
+
+
+# ----- _run_cn_update_contact -------------------------------------------------
+
+
+def test_update_contact_raises_not_found_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _, save_req, _ = _install_fake_contacts_for_modify(
+        monkeypatch, fetched_contact=None
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsNotFoundError):
+        connector._run_cn_update_contact("missing", {"given_name": "X"})
+    save_req.updateContact_.assert_not_called()
+    store.executeSaveRequest_error_.assert_not_called()
+
+
+def test_update_contact_only_supplied_setters_fire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetched = MagicMock(name="CNContact_fetched")
+    store, mutable, save_req, _ = _install_fake_contacts_for_modify(
+        monkeypatch, fetched_contact=fetched
+    )
+    connector = ContactsConnector()
+    result = connector._run_cn_update_contact(
+        "ABCD", {"given_name": "Alice"}
+    )
+    assert result == "ABCD"
+    mutable.setGivenName_.assert_called_once_with("Alice")
+    mutable.setFamilyName_.assert_not_called()
+    mutable.setOrganizationName_.assert_not_called()
+    mutable.setPhoneNumbers_.assert_not_called()
+    mutable.setBirthday_.assert_not_called()
+    save_req.updateContact_.assert_called_once_with(mutable)
+    store.executeSaveRequest_error_.assert_called_once()
+
+
+def test_update_contact_empty_string_clears_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Presence semantics: passing given_name='' clears, doesn't skip."""
+    fetched = MagicMock(name="CNContact_fetched")
+    _, mutable, _, _ = _install_fake_contacts_for_modify(
+        monkeypatch, fetched_contact=fetched
+    )
+    connector = ContactsConnector()
+    connector._run_cn_update_contact("ABCD", {"given_name": ""})
+    mutable.setGivenName_.assert_called_once_with("")
+
+
+def test_update_contact_phones_empty_list_clears_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetched = MagicMock(name="CNContact_fetched")
+    _, mutable, _, _ = _install_fake_contacts_for_modify(
+        monkeypatch, fetched_contact=fetched
+    )
+    connector = ContactsConnector()
+    connector._run_cn_update_contact("ABCD", {"phones": []})
+    mutable.setPhoneNumbers_.assert_called_once_with([])
+
+
+def test_update_contact_phones_replaces_with_supplied_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetched = MagicMock(name="CNContact_fetched")
+    _, mutable, _, _ = _install_fake_contacts_for_modify(
+        monkeypatch, fetched_contact=fetched
+    )
+    connector = ContactsConnector()
+    connector._run_cn_update_contact(
+        "ABCD",
+        {"phones": [{"label_raw": "_$!<Mobile>!$_", "value": "+1 555-1212"}]},
+    )
+    mutable.setPhoneNumbers_.assert_called_once()
+    args, _ = mutable.setPhoneNumbers_.call_args
+    assert len(args[0]) == 1
+
+
+def test_update_contact_birthday_replaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetched = MagicMock(name="CNContact_fetched")
+    _, mutable, _, _ = _install_fake_contacts_for_modify(
+        monkeypatch, fetched_contact=fetched
+    )
+    connector = ContactsConnector()
+    connector._run_cn_update_contact(
+        "ABCD", {"birthday": {"year": 1991, "month": 6, "day": 1}}
+    )
+    mutable.setBirthday_.assert_called_once()
+
+
+def test_update_contact_save_failure_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetched = MagicMock(name="CNContact_fetched")
+    fake_save_error = MagicMock(name="NSError(save)")
+    fake_save_error.__str__.return_value = "save boom"
+    _install_fake_contacts_for_modify(
+        monkeypatch,
+        fetched_contact=fetched,
+        save_succeeds=False,
+        fake_save_error=fake_save_error,
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_update_contact("ABCD", {"given_name": "X"})
+    assert "save boom" in str(exc_info.value)
+
+
+# ----- _run_cn_delete_contact -------------------------------------------------
+
+
+def test_delete_contact_raises_not_found_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _, save_req, _ = _install_fake_contacts_for_modify(
+        monkeypatch, fetched_contact=None
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsNotFoundError):
+        connector._run_cn_delete_contact("missing")
+    save_req.deleteContact_.assert_not_called()
+    store.executeSaveRequest_error_.assert_not_called()
+
+
+def test_delete_contact_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    fetched = MagicMock(name="CNContact_fetched")
+    store, mutable, save_req, _ = _install_fake_contacts_for_modify(
+        monkeypatch, fetched_contact=fetched
+    )
+    connector = ContactsConnector()
+    result = connector._run_cn_delete_contact("ABCD")
+    assert result == "ABCD"
+    save_req.deleteContact_.assert_called_once_with(mutable)
+    store.executeSaveRequest_error_.assert_called_once()
+
+
+def test_delete_contact_save_failure_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetched = MagicMock(name="CNContact_fetched")
+    fake_save_error = MagicMock(name="NSError(save)")
+    fake_save_error.__str__.return_value = "delete boom"
+    _install_fake_contacts_for_modify(
+        monkeypatch,
+        fetched_contact=fetched,
+        save_succeeds=False,
+        fake_save_error=fake_save_error,
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_delete_contact("ABCD")
+    assert "delete boom" in str(exc_info.value)

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -16,6 +16,7 @@ from apple_contacts_mcp.security import (
     DESTRUCTIVE_OPERATIONS,
     _get_test_group_identifiers,
     check_test_mode_safety,
+    require_test_mode_for,
 )
 
 
@@ -207,3 +208,40 @@ def _subprocess_failure() -> Any:
         raise FileNotFoundError("osascript not available in test env")
 
     return _boom
+
+
+# ---------------------------------------------------------------------------
+# require_test_mode_for
+# ---------------------------------------------------------------------------
+
+
+class TestRequireTestModeFor:
+    def test_env_unset_returns_safety_violation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        result = require_test_mode_for("delete_contact")
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+        assert "delete_contact" in result["error"]
+        assert "v0.4.0" in result["error"]
+
+    def test_env_false_returns_safety_violation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "false")
+        result = require_test_mode_for("delete_contact")
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+
+    def test_env_true_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        assert require_test_mode_for("delete_contact") is None
+
+    def test_env_TRUE_case_insensitive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "TRUE")
+        assert require_test_mode_for("delete_contact") is None

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -12,12 +12,15 @@ from apple_contacts_mcp.exceptions import (
     ContactsNotFoundError,
     ContactsTimeoutError,
 )
+from apple_contacts_mcp.security import _get_test_group_identifiers
 from apple_contacts_mcp.server import (
     check_authorization,
     create_contact,
+    delete_contact,
     get_contact,
     list_contacts,
     search_contacts,
+    update_contact,
 )
 
 
@@ -631,3 +634,258 @@ class TestCreateContactSaveFailure:
         assert result["success"] is False
         assert result["error_type"] == "unknown"
         assert "save boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# update_contact
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateContactValidation:
+    def test_empty_identifier_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = update_contact(identifier="", given_name="X")
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_authorization_status.assert_not_called()
+
+    def test_no_fields_supplied_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = update_contact(identifier="ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        assert "at least one" in result["error"].lower()
+        mock_connector._run_cn_update_contact.assert_not_called()
+
+    def test_email_without_at_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = update_contact(
+                identifier="ABCD",
+                emails=[{"label_raw": "", "value": "no-at-sign"}],
+            )
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_update_contact.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "bday",
+        [
+            {"month": 13, "day": 1},
+            {"month": 5, "day": 32},
+            {"year": -1, "month": 5, "day": 15},
+        ],
+    )
+    def test_invalid_birthday_returns_validation_error(
+        self, bday: dict[str, int]
+    ) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = update_contact(identifier="ABCD", birthday=bday)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_update_contact.assert_not_called()
+
+
+class TestUpdateContactAuthFlow:
+    def test_auth_denied_passthrough_skips_update(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "denied"
+            result = update_contact(identifier="ABCD", given_name="Alice")
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        mock_connector._run_cn_update_contact.assert_not_called()
+
+
+class TestUpdateContactTestModeSafety:
+    def test_test_mode_without_group_arg_blocked(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = update_contact(identifier="ABCD", given_name="Alice")
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        mock_connector._run_cn_update_contact.assert_not_called()
+
+    def test_test_mode_with_matching_group_proceeds(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_update_contact.return_value = "ABCD"
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = update_contact(
+                    identifier="ABCD",
+                    given_name="Alice",
+                    group_identifier="MCP-Test",
+                )
+        assert result == {"success": True, "identifier": "ABCD"}
+
+
+class TestUpdateContactHappyPath:
+    def test_single_field_passes_only_that_key_to_connector(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_update_contact.return_value = "ABCD"
+            result = update_contact(identifier="ABCD", given_name="Alice")
+        assert result == {"success": True, "identifier": "ABCD"}
+        kwargs = mock_connector._run_cn_update_contact.call_args.kwargs
+        assert kwargs["identifier"] == "ABCD"
+        assert kwargs["fields"] == {"given_name": "Alice"}
+
+    def test_empty_string_clears_field_via_presence(self) -> None:
+        """given_name='' must reach the connector (presence semantics)."""
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_update_contact.return_value = "ABCD"
+            update_contact(identifier="ABCD", given_name="")
+        kwargs = mock_connector._run_cn_update_contact.call_args.kwargs
+        assert kwargs["fields"] == {"given_name": ""}
+
+    def test_phones_empty_list_reaches_connector(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_update_contact.return_value = "ABCD"
+            update_contact(identifier="ABCD", phones=[])
+        kwargs = mock_connector._run_cn_update_contact.call_args.kwargs
+        assert kwargs["fields"] == {"phones": []}
+
+    def test_response_keys_are_minimal(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_update_contact.return_value = "ABCD"
+            result = update_contact(identifier="ABCD", given_name="A")
+        assert set(result.keys()) == {"success", "identifier"}
+
+
+class TestUpdateContactErrors:
+    def test_not_found_from_connector(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_update_contact.side_effect = (
+                ContactsNotFoundError("Contact not found: 'BAD'")
+            )
+            result = update_contact(identifier="BAD", given_name="X")
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+        assert "BAD" in result["error"]
+
+    def test_save_failure_returns_unknown(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_update_contact.side_effect = ContactsError(
+                "save boom"
+            )
+            result = update_contact(identifier="ABCD", given_name="X")
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "save boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# delete_contact
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteContactValidation:
+    def test_empty_identifier_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = delete_contact(identifier="")
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_authorization_status.assert_not_called()
+
+
+class TestDeleteContactRequiresTestMode:
+    def test_test_mode_off_returns_safety_violation(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = delete_contact(identifier="ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        assert "CONTACTS_TEST_MODE" in result["error"]
+        # Auth was NOT triggered (no TCC prompt for an op we refused).
+        mock_connector._run_cn_authorization_status.assert_not_called()
+        mock_connector._run_cn_delete_contact.assert_not_called()
+
+    def test_test_mode_explicit_false_returns_safety_violation(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "false")
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = delete_contact(identifier="ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        mock_connector._run_cn_authorization_status.assert_not_called()
+
+
+class TestDeleteContactTestGroupGate:
+    def test_test_mode_on_no_group_arg_blocked(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = delete_contact(identifier="ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        mock_connector._run_cn_delete_contact.assert_not_called()
+
+    def test_test_mode_on_with_matching_group_proceeds(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_delete_contact.return_value = "ABCD"
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = delete_contact(
+                    identifier="ABCD", group_identifier="MCP-Test"
+                )
+        assert result == {"success": True, "identifier": "ABCD"}
+
+
+class TestDeleteContactErrors:
+    def test_not_found_from_connector(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_delete_contact.side_effect = (
+                ContactsNotFoundError("Contact not found: 'BAD'")
+            )
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = delete_contact(
+                    identifier="BAD", group_identifier="MCP-Test"
+                )
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+
+    def test_save_failure_returns_unknown(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_delete_contact.side_effect = ContactsError(
+                "delete boom"
+            )
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = delete_contact(
+                    identifier="ABCD", group_identifier="MCP-Test"
+                )
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "delete boom" in result["error"]


### PR DESCRIPTION
Closes #14.

## Summary

Finishes v0.1.0's CRUD surface. Two destructive tools that complete the create/read/update/delete loop.

```jsonc
update_contact(identifier="ABCD", given_name="Alice", phones=[{"label_raw": "_$!<Mobile>!$_", "value": "+1 555-1212"}])
{"success": true, "identifier": "ABCD"}

delete_contact(identifier="ABCD", group_identifier="MCP-Test")  // test mode only in v0.1.0
{"success": true, "identifier": "ABCD"}
```

## Design notes

### `update_contact` — partial-dict / presence semantics

Every field defaults to `None` ("don't touch"). Asymmetric with `create_contact`'s `""` defaults — justified because update needs to distinguish "not supplied" from "explicitly clear", whereas create has nothing to overwrite.

| Caller passes | Behavior |
|---|---|
| `given_name=None` (default) | Don't touch |
| `given_name=""` | Explicitly clear |
| `given_name="Alice"` | Set |
| `phones=None` | Don't touch |
| `phones=[]` | Clear all phones |
| `phones=[{...}]` | **Replace** all phones (REST-PUT, not append) |

At least one field must be supplied — otherwise `validation_error`. LLM can call `get_contact(id)` afterward to read back the updated record.

### `delete_contact` — gated to test mode in v0.1.0

Per the issue: "Delete requires confirmation flow when implemented (v0.4.0); for v0.1.0 it gates on `CONTACTS_TEST_MODE`."

Adds `require_test_mode_for(operation)` to [security.py](src/apple_contacts_mcp/security.py) — refuses entirely when test mode is OFF. Composes with the existing `check_test_mode_safety` to enforce the test-group constraint when test mode is ON. Order in the tool body puts `require_test_mode_for` **before** the auth gate so users outside test mode never see a TCC prompt for an op we'd refuse anyway.

Full destructive UX (with confirmation prompts) ships in v0.4.0 (#24).

### New connector helpers

- `_run_cn_update_contact(identifier, fields)` — fetches with full P1 keys, `mutableCopy()`, applies `_apply_update_fields`, saves via `CNSaveRequest.updateContact_`.
- `_run_cn_delete_contact(identifier)` — fetches with just identifier key, `mutableCopy()`, saves via `CNSaveRequest.deleteContact_`.
- `_apply_update_fields(mutable, fields)` — module-private; uses **presence** check (`"key" in fields`) not truthy, so empty strings explicitly clear. Reuses `_build_mutable_postal_address` and `_build_birthday_components` from #13.

Both helpers raise `ContactsNotFoundError` on missing identifier (mapped to `error_type: "not_found"` at the server boundary).

## Test plan

- [x] `make test` — 166 tests (36 new), all pass
- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy strict clean
- [x] `make coverage` — 96.12% project-wide; security.py 100%, server.py 95%
- [x] `make check-all` — full gate green; client/server parity reports all 7 tools (check_authorization, create_contact, delete_contact, get_contact, list_contacts, search_contacts, update_contact)

## Out of scope (deferred)

- Confirmation UX before delete → v0.4.0 (#24).
- Group-membership changes via `update_contact` → v0.2.0+ (`add_member_to_group` / `remove_member_from_group` tools).
- Clearing birthday entirely (clear-via-sentinel) → v0.2.0+; document as "use Apple Contacts.app" for now.
- Rate-limit + audit-log call sites → #46, #47 (v0.4.0).
- Real-Contacts integration test → #15.
- Returning the updated contact dict in the response → keep `{success, identifier}` for symmetry with create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)