### PR TITLE
test: integration test rig for v0.1.0 tools

### DIFF
--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -147,7 +147,18 @@ class ContactsConnector:
                 skipped += 1
                 return
             if len(contacts) >= limit:
-                stop_ptr[0] = True
+                # Apple's `BOOL *stop` arrives via PyObjC as either a
+                # mutable 1-element sequence or None depending on the
+                # selector's metadata — for `enumerateContactsWith...`
+                # it's None in practice. Guard defensively; if we can't
+                # short-circuit we just keep returning early (the
+                # framework still walks the rest, but we don't pay the
+                # serialization cost).
+                if stop_ptr is not None:
+                    try:
+                        stop_ptr[0] = True
+                    except (TypeError, IndexError):
+                        pass
                 return
             contacts.append(
                 {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,211 @@
+"""Integration-test fixtures. Real CN access — needs TCC permission.
+
+These fixtures touch the user's real Apple Contacts database. They
+should NEVER be imported from a unit test. The session fixtures below
+trigger real Contacts.framework I/O and may prompt for TCC access on
+first run.
+
+Lifecycle:
+1. ``real_connector`` checks TCC status. If notDetermined, calls
+   ``_run_cn_request_access`` and waits up to 15s for the user to
+   click Allow. If denied/restricted, the entire session is skipped
+   with a clear message.
+2. ``test_group`` finds-or-creates the ``MCP-Test`` group via raw CN
+   calls (group CRUD helpers don't exist in the production connector
+   yet — those are v0.2.0+). Yields its CN identifier.
+3. ``integration_env`` sets ``CONTACTS_TEST_MODE=true`` and
+   ``CONTACTS_TEST_GROUP=MCP-Test`` for the session so the
+   destructive-op gates from #6/#13/#14 are armed.
+4. ``tmp_contact`` (function-scoped) creates a contact in the test
+   group, yields its identifier, deletes on teardown.
+5. Session teardown: every contact in ``MCP-Test`` is deleted, then
+   the group itself. Best-effort — failures log, never raise (would
+   mask real test failures).
+
+Risks:
+- **Pre-existing ``MCP-Test`` group**: if you happen to have a real
+  group by that exact name with real members, the session teardown
+  will delete them. Choose a different ``CONTACTS_TEST_GROUP`` name
+  if so.
+- **Crashed test process**: leaked contacts in ``MCP-Test`` are
+  cleaned up on the next session (find-or-create + cleanup).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from apple_contacts_mcp.contacts_connector import ContactsConnector
+
+logger = logging.getLogger(__name__)
+TEST_GROUP_NAME = "MCP-Test"
+
+
+# ---------------------------------------------------------------------------
+# Session fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def integration_env() -> Iterator[None]:
+    """Force CONTACTS_TEST_MODE + CONTACTS_TEST_GROUP for the session."""
+    mp = pytest.MonkeyPatch()
+    mp.setenv("CONTACTS_TEST_MODE", "true")
+    mp.setenv("CONTACTS_TEST_GROUP", TEST_GROUP_NAME)
+    # Defensive: clear any cached test-group identifier resolution.
+    from apple_contacts_mcp.security import _get_test_group_identifiers
+
+    _get_test_group_identifiers.cache_clear()
+    try:
+        yield
+    finally:
+        mp.undo()
+
+
+@pytest.fixture(scope="session")
+def real_connector() -> ContactsConnector:
+    """Real connector. Skips the session if TCC is unavailable."""
+    c = ContactsConnector(timeout=15.0)
+    status = c._run_cn_authorization_status()
+    if status in ("denied", "restricted"):
+        pytest.skip(
+            f"Contacts permission status={status}; grant in System "
+            "Settings → Privacy & Security → Contacts and re-run."
+        )
+    if status == "notDetermined":
+        try:
+            granted = c._run_cn_request_access()
+        except Exception as exc:
+            pytest.skip(f"requestAccess failed: {exc}")
+        if not granted:
+            pytest.skip("User did not grant Contacts access.")
+    return c
+
+
+@pytest.fixture(scope="session")
+def test_group(
+    real_connector: ContactsConnector, integration_env: None
+) -> Iterator[str]:
+    """Find or create the MCP-Test group; yield its identifier; cleanup."""
+    group_id = _find_or_create_test_group(real_connector)
+    try:
+        yield group_id
+    finally:
+        _cleanup_test_group(real_connector, group_id)
+
+
+# ---------------------------------------------------------------------------
+# Function-scoped fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_contact(
+    real_connector: ContactsConnector, test_group: str
+) -> Iterator[str]:
+    """Create a contact in the test group; yield its identifier; delete on
+    teardown (best-effort, doesn't mask test failures)."""
+    fields = {"given_name": "Integration", "family_name": "Fixture"}
+    identifier = real_connector._run_cn_create_contact(
+        fields=fields, group_identifier=test_group
+    )
+    try:
+        yield identifier
+    finally:
+        try:
+            real_connector._run_cn_delete_contact(identifier)
+        except Exception as exc:
+            logger.warning("tmp_contact teardown failed for %s: %s", identifier, exc)
+
+
+# ---------------------------------------------------------------------------
+# Raw CN helpers used by the fixtures (group CRUD is v0.2.0+; lives here for now)
+# ---------------------------------------------------------------------------
+
+
+def _find_or_create_test_group(connector: ContactsConnector) -> str:
+    """Return the CN identifier of the MCP-Test group, creating it if missing."""
+    from Contacts import CNMutableGroup, CNSaveRequest
+
+    store = connector._get_store()
+    existing = _find_group_by_name(connector, TEST_GROUP_NAME)
+    if existing is not None:
+        identifier = str(existing.identifier())
+        logger.info(
+            "Reusing existing %r group (id=%s). Members will be deleted at "
+            "session teardown.",
+            TEST_GROUP_NAME,
+            identifier,
+        )
+        return identifier
+
+    new_group = CNMutableGroup.alloc().init()
+    new_group.setName_(TEST_GROUP_NAME)
+    save_req = CNSaveRequest.alloc().init()
+    save_req.addGroup_toContainerWithIdentifier_(new_group, None)
+    ok, err = store.executeSaveRequest_error_(save_req, None)
+    if not ok:
+        raise RuntimeError(f"Failed to create test group: {err}")
+    return str(new_group.identifier())
+
+
+def _find_group_by_name(connector: ContactsConnector, name: str) -> Any | None:
+    """Return the first CNGroup whose .name() matches; None if no match."""
+    store = connector._get_store()
+    groups, err = store.groupsMatchingPredicate_error_(None, None)
+    if groups is None:
+        raise RuntimeError(f"groupsMatchingPredicate failed: {err}")
+    for g in groups:
+        if str(g.name()) == name:
+            return g
+    return None
+
+
+def _cleanup_test_group(connector: ContactsConnector, group_id: str) -> None:
+    """Delete every contact in the group, then the group itself.
+
+    Best-effort. Logs failures, never raises — the session is wrapping
+    up and we don't want to mask real test failures.
+    """
+    from Contacts import CNContact, CNContactIdentifierKey, CNSaveRequest
+
+    try:
+        store = connector._get_store()
+        pred = CNContact.predicateForContactsInGroupWithIdentifier_(group_id)
+        contacts, err = store.unifiedContactsMatchingPredicate_keysToFetch_error_(
+            pred, [CNContactIdentifierKey], None
+        )
+        if contacts is None:
+            logger.warning(
+                "Could not enumerate %r members for cleanup: %s",
+                TEST_GROUP_NAME,
+                err,
+            )
+            contacts = []
+
+        save_req = CNSaveRequest.alloc().init()
+        for c in contacts:
+            save_req.deleteContact_(c.mutableCopy())
+
+        try:
+            group = connector._run_cn_fetch_group(group_id)
+        except Exception as exc:
+            logger.warning("fetch_group during cleanup failed: %s", exc)
+            group = None
+        if group is not None:
+            save_req.deleteGroup_(group.mutableCopy())
+
+        ok, err = store.executeSaveRequest_error_(save_req, None)
+        if not ok:
+            logger.warning(
+                "Cleanup save failed for %r (group_id=%s): %s",
+                TEST_GROUP_NAME,
+                group_id,
+                err,
+            )
+    except Exception as exc:
+        logger.warning("Cleanup of %r raised: %s", TEST_GROUP_NAME, exc)

--- a/tests/integration/test_authorization.py
+++ b/tests/integration/test_authorization.py
@@ -1,0 +1,42 @@
+"""Integration tests for the TCC authorization helpers.
+
+Skipped by default; opt in with ``--run-integration``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apple_contacts_mcp.contacts_connector import ContactsConnector
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        "not config.getoption('--run-integration')",
+        reason="Integration tests opt-in via --run-integration",
+    ),
+]
+
+
+_VALID_STATUSES = {"notDetermined", "restricted", "denied", "authorized", "limited"}
+
+
+def test_authorization_status_returns_known_value(
+    real_connector: ContactsConnector,
+) -> None:
+    """The status getter returns one of the five documented strings."""
+    status = real_connector._run_cn_authorization_status()
+    assert status in _VALID_STATUSES
+
+
+def test_request_access_when_already_authorized(
+    real_connector: ContactsConnector,
+) -> None:
+    """Once authorized, calling requestAccess again is idempotent (returns True
+    without re-prompting)."""
+    status = real_connector._run_cn_authorization_status()
+    if status not in ("authorized", "limited"):
+        pytest.skip(
+            f"This test requires authorized/limited status; got {status}."
+        )
+    assert real_connector._run_cn_request_access() is True

--- a/tests/integration/test_crud_path.py
+++ b/tests/integration/test_crud_path.py
@@ -1,0 +1,266 @@
+"""Integration tests for the CNSaveRequest write path.
+
+Skipped by default; opt in with ``--run-integration``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from apple_contacts_mcp.contacts_connector import ContactsConnector
+from apple_contacts_mcp.exceptions import ContactsNotFoundError
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        "not config.getoption('--run-integration')",
+        reason="Integration tests opt-in via --run-integration",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_create_contact
+# ---------------------------------------------------------------------------
+
+
+def test_create_minimal_returns_identifier(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """A bare-minimum contact returns a non-empty CN identifier."""
+    identifier = real_connector._run_cn_create_contact(
+        fields={"given_name": "MinimalCreate"},
+        group_identifier=test_group,
+    )
+    try:
+        assert isinstance(identifier, str)
+        assert identifier
+    finally:
+        real_connector._run_cn_delete_contact(identifier)
+
+
+def test_create_with_group_attaches_membership(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """A contact created with group_identifier shows up in the group's members."""
+    from Contacts import CNContact, CNContactIdentifierKey
+
+    identifier = real_connector._run_cn_create_contact(
+        fields={"given_name": "GroupedCreate"},
+        group_identifier=test_group,
+    )
+    try:
+        store = real_connector._get_store()
+        pred = CNContact.predicateForContactsInGroupWithIdentifier_(test_group)
+        members, _err = store.unifiedContactsMatchingPredicate_keysToFetch_error_(
+            pred, [CNContactIdentifierKey], None
+        )
+        ids = {str(m.identifier()) for m in (members or [])}
+        assert identifier in ids
+    finally:
+        real_connector._run_cn_delete_contact(identifier)
+
+
+def test_create_with_full_p1_fields_round_trips(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """Every P1 field type written via create reads back via fetch."""
+    fields = {
+        "given_name": "Full",
+        "family_name": "Roundtrip",
+        "middle_name": "M",
+        "name_prefix": "Dr.",
+        "name_suffix": "Jr.",
+        "nickname": "Roundy",
+        "organization": "Acme",
+        "job_title": "Engineer",
+        "department": "R&D",
+        "phones": [
+            {"label_raw": "_$!<Mobile>!$_", "value": "+1 555-1212"}
+        ],
+        "emails": [
+            {"label_raw": "_$!<Home>!$_", "value": "round@example.com"}
+        ],
+        "urls": [{"label_raw": "_$!<HomePage>!$_", "value": "https://example.com"}],
+        "postal_addresses": [
+            {
+                "label_raw": "_$!<Home>!$_",
+                "street": "1 Loop",
+                "city": "Cupertino",
+                "state": "CA",
+                "postal_code": "95014",
+                "country": "USA",
+                "iso_country_code": "us",
+            }
+        ],
+        "birthday": {"year": 1990, "month": 5, "day": 15},
+    }
+    identifier = real_connector._run_cn_create_contact(
+        fields=fields, group_identifier=test_group
+    )
+    try:
+        result = real_connector._run_cn_unified_contact(identifier)
+        assert result is not None
+        assert result["given_name"] == "Full"
+        assert result["family_name"] == "Roundtrip"
+        assert result["organization"] == "Acme"
+        assert result["job_title"] == "Engineer"
+        assert len(result["phones"]) == 1
+        assert result["phones"][0]["value"] == "+1 555-1212"
+        assert len(result["emails"]) == 1
+        assert result["emails"][0]["value"] == "round@example.com"
+        assert len(result["urls"]) == 1
+        assert len(result["postal_addresses"]) == 1
+        assert result["postal_addresses"][0]["city"] == "Cupertino"
+        assert result["birthday"] == {"year": 1990, "month": 5, "day": 15}
+    finally:
+        real_connector._run_cn_delete_contact(identifier)
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_update_contact
+# ---------------------------------------------------------------------------
+
+
+def test_update_partial_only_changes_supplied_field(
+    real_connector: ContactsConnector, tmp_contact: str
+) -> None:
+    """Updating just given_name leaves family_name intact."""
+    real_connector._run_cn_update_contact(
+        identifier=tmp_contact, fields={"given_name": "Updated"}
+    )
+    result = real_connector._run_cn_unified_contact(tmp_contact)
+    assert result is not None
+    assert result["given_name"] == "Updated"
+    assert result["family_name"] == "Fixture"  # untouched
+
+
+def test_update_with_empty_string_clears_field(
+    real_connector: ContactsConnector, tmp_contact: str
+) -> None:
+    """Passing family_name='' explicitly clears it (presence semantics)."""
+    real_connector._run_cn_update_contact(
+        identifier=tmp_contact, fields={"family_name": ""}
+    )
+    result = real_connector._run_cn_unified_contact(tmp_contact)
+    assert result is not None
+    assert result["family_name"] == ""
+
+
+def test_update_replaces_phones(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """Updating with a new phones list replaces (not appends)."""
+    identifier = real_connector._run_cn_create_contact(
+        fields={
+            "given_name": "PhoneReplace",
+            "phones": [{"label_raw": "_$!<Home>!$_", "value": "+1 555-1111"}],
+        },
+        group_identifier=test_group,
+    )
+    try:
+        real_connector._run_cn_update_contact(
+            identifier=identifier,
+            fields={
+                "phones": [
+                    {"label_raw": "_$!<Mobile>!$_", "value": "+1 555-2222"}
+                ]
+            },
+        )
+        result = real_connector._run_cn_unified_contact(identifier)
+        assert result is not None
+        assert len(result["phones"]) == 1
+        assert result["phones"][0]["value"] == "+1 555-2222"
+    finally:
+        real_connector._run_cn_delete_contact(identifier)
+
+
+def test_update_raises_not_found_for_missing_identifier(
+    real_connector: ContactsConnector,
+) -> None:
+    fabricated = f"fabricated-{uuid.uuid4()}"
+    with pytest.raises(ContactsNotFoundError):
+        real_connector._run_cn_update_contact(
+            identifier=fabricated, fields={"given_name": "X"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_delete_contact
+# ---------------------------------------------------------------------------
+
+
+def test_delete_removes_contact(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """After delete, the contact is gone from the store."""
+    identifier = real_connector._run_cn_create_contact(
+        fields={"given_name": "DeleteMe"},
+        group_identifier=test_group,
+    )
+    real_connector._run_cn_delete_contact(identifier)
+    assert real_connector._run_cn_unified_contact(identifier) is None
+
+
+def test_delete_raises_not_found_for_missing_identifier(
+    real_connector: ContactsConnector,
+) -> None:
+    fabricated = f"fabricated-{uuid.uuid4()}"
+    with pytest.raises(ContactsNotFoundError):
+        real_connector._run_cn_delete_contact(fabricated)
+
+
+# ---------------------------------------------------------------------------
+# Full CRUD smoke
+# ---------------------------------------------------------------------------
+
+
+def test_full_crud_cycle(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """create → fetch → update → fetch → delete → fetch returns None."""
+    identifier = real_connector._run_cn_create_contact(
+        fields={"given_name": "Crud", "family_name": "Cycle"},
+        group_identifier=test_group,
+    )
+    try:
+        # Fetch after create.
+        first = real_connector._run_cn_unified_contact(identifier)
+        assert first is not None
+        assert first["given_name"] == "Crud"
+
+        # Update.
+        real_connector._run_cn_update_contact(
+            identifier=identifier,
+            fields={
+                "family_name": "Updated",
+                "organization": "AcmeCRUD",
+                "phones": [
+                    {"label_raw": "_$!<Mobile>!$_", "value": "+1 555-9999"}
+                ],
+            },
+        )
+
+        # Fetch after update.
+        second = real_connector._run_cn_unified_contact(identifier)
+        assert second is not None
+        assert second["given_name"] == "Crud"  # not touched
+        assert second["family_name"] == "Updated"
+        assert second["organization"] == "AcmeCRUD"
+        assert second["phones"][0]["value"] == "+1 555-9999"
+
+        # Delete.
+        real_connector._run_cn_delete_contact(identifier)
+    except Exception:
+        # If something went wrong mid-cycle, attempt cleanup so the next run
+        # doesn't trip over a leaked contact (best-effort).
+        try:
+            real_connector._run_cn_delete_contact(identifier)
+        except Exception:
+            pass
+        raise
+
+    # Fetch after delete.
+    assert real_connector._run_cn_unified_contact(identifier) is None

--- a/tests/integration/test_read_path.py
+++ b/tests/integration/test_read_path.py
@@ -1,0 +1,142 @@
+"""Integration tests for read-path connector helpers.
+
+Skipped by default; opt in with ``--run-integration``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from apple_contacts_mcp.contacts_connector import ContactsConnector
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        "not config.getoption('--run-integration')",
+        reason="Integration tests opt-in via --run-integration",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_enumerate_contacts
+# ---------------------------------------------------------------------------
+
+
+def test_enumerate_returns_dicts_with_expected_shape(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """The first page is dicts with the documented 4 keys, all str values."""
+    results = real_connector._run_cn_enumerate_contacts(offset=0, limit=10)
+    assert isinstance(results, list)
+    for entry in results:
+        assert set(entry.keys()) == {
+            "id",
+            "given_name",
+            "family_name",
+            "organization",
+        }
+        for v in entry.values():
+            assert isinstance(v, str)
+
+
+def test_enumerate_offset_advances(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """Calling enumerate with offset=N+M returns a different first entry
+    than offset=0 (assuming the store has at least M+1 contacts).
+
+    Skipped automatically if the test machine has fewer than 2 contacts.
+    """
+    first_page = real_connector._run_cn_enumerate_contacts(offset=0, limit=2)
+    if len(first_page) < 2:
+        pytest.skip("Need at least 2 contacts in the store to test offset advance.")
+    offset_page = real_connector._run_cn_enumerate_contacts(offset=1, limit=1)
+    assert offset_page[0]["id"] == first_page[1]["id"]
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_unified_contact
+# ---------------------------------------------------------------------------
+
+
+def test_unified_contact_round_trips_basic_fields(
+    real_connector: ContactsConnector, tmp_contact: str
+) -> None:
+    """A contact created with given_name/family_name fetches back with those
+    exact values plus empty defaults for unset fields."""
+    result = real_connector._run_cn_unified_contact(tmp_contact)
+    assert result is not None
+    assert result["id"] == tmp_contact
+    assert result["given_name"] == "Integration"
+    assert result["family_name"] == "Fixture"
+    assert result["organization"] == ""
+    assert result["phones"] == []
+    assert result["emails"] == []
+    assert result["postal_addresses"] == []
+    assert result["birthday"] is None
+
+
+def test_unified_contact_returns_none_for_missing_id(
+    real_connector: ContactsConnector,
+) -> None:
+    """A fabricated identifier returns None (not raise)."""
+    fabricated = f"fabricated-{uuid.uuid4()}"
+    assert real_connector._run_cn_unified_contact(fabricated) is None
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_search_contacts
+# ---------------------------------------------------------------------------
+
+
+def test_search_finds_contact_by_unique_name(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """A contact created with a unique name is findable by predicate."""
+    unique_token = f"IntegSearch{uuid.uuid4().hex[:8]}"
+    identifier = real_connector._run_cn_create_contact(
+        fields={"given_name": unique_token, "family_name": "Searchable"},
+        group_identifier=test_group,
+    )
+    try:
+        results = real_connector._run_cn_search_contacts(
+            query=unique_token, limit=10
+        )
+        ids = {entry["id"] for entry in results}
+        assert identifier in ids
+    finally:
+        real_connector._run_cn_delete_contact(identifier)
+
+
+def test_search_no_match_returns_empty(
+    real_connector: ContactsConnector,
+) -> None:
+    """A query guaranteed to miss returns an empty list."""
+    impossible = f"NoSuchPerson-{uuid.uuid4().hex}"
+    assert real_connector._run_cn_search_contacts(query=impossible, limit=10) == []
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_fetch_group
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_group_returns_test_group(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """Fetching the test group's identifier returns a CNGroup whose name
+    matches the configured CONTACTS_TEST_GROUP."""
+    group = real_connector._run_cn_fetch_group(test_group)
+    assert group is not None
+    assert str(group.name()) == "MCP-Test"
+
+
+def test_fetch_group_returns_none_for_missing_id(
+    real_connector: ContactsConnector,
+) -> None:
+    """Fabricated identifier returns None."""
+    fabricated = f"fabricated-{uuid.uuid4()}"
+    assert real_connector._run_cn_fetch_group(fabricated) is None

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -352,6 +352,54 @@ def test_enumerate_stops_after_limit_via_stop_ptr(
     assert fakes[3].identifier.call_count == 0
 
 
+def test_enumerate_handles_none_stop_ptr_without_crashing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real PyObjC passes `BOOL *stop` as None for this selector — the
+    callback must not raise when trying to short-circuit. We just stop
+    serializing and let the framework finish its walk.
+
+    Caught by integration testing (issue #15); regression test added at
+    the unit level so it doesn't recur silently.
+    """
+    fake_module = types.ModuleType("Contacts")
+    fake_module.CNContactIdentifierKey = "id_key"  # type: ignore[attr-defined]
+    fake_module.CNContactGivenNameKey = "given_key"  # type: ignore[attr-defined]
+    fake_module.CNContactFamilyNameKey = "family_key"  # type: ignore[attr-defined]
+    fake_module.CNContactOrganizationNameKey = "org_key"  # type: ignore[attr-defined]
+    fetch_request_class = MagicMock(name="CNContactFetchRequest")
+    fetch_request_class.alloc.return_value.initWithKeysToFetch_.return_value = (
+        MagicMock()
+    )
+    fake_module.CNContactFetchRequest = fetch_request_class  # type: ignore[attr-defined]
+
+    cn_store_class = MagicMock(name="CNContactStore")
+    store_instance = MagicMock(name="store_instance")
+    fakes = [_make_fake_contact(f"id-{i}", "G", "F", "O") for i in range(5)]
+
+    def fake_enumerate(
+        _req: Any, _err: Any, callback: Any
+    ) -> tuple[bool, object | None]:
+        # Pass None to mimic real PyObjC behavior for this selector.
+        for contact in fakes:
+            callback(contact, None)
+        return True, None
+
+    store_instance.enumerateContactsWithFetchRequest_error_usingBlock_.side_effect = (
+        fake_enumerate
+    )
+    cn_store_class.alloc.return_value.init.return_value = store_instance
+    fake_module.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "Contacts", fake_module)
+
+    connector = ContactsConnector()
+    # limit=2 means after 2 contacts we want to stop, but stop_ptr is None.
+    # The helper should still return only 2 (early-return in the callback)
+    # and not crash trying to mutate None.
+    result = connector._run_cn_enumerate_contacts(offset=0, limit=2)
+    assert [c["id"] for c in result] == ["id-0", "id-1"]
+
+
 def test_enumerate_skips_offset_then_returns_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes #15.

## Summary

Adds the integration test suite for v0.1.0. Every `_run_cn_*` helper now has at least one test that hits a real `CNContactStore`. Skip-by-default via the existing `--run-integration` flag and `integration` marker.

```
$ make test          # 167 unit tests, 20 integration deselected via marker
$ make test-integration   # 20 integration tests against real Contacts.app
```

## Real bug caught (the whole point of this PR)

`_run_cn_enumerate_contacts` crashed with `'NoneType' object does not support item assignment` on the first integration run. Apple's `BOOL *stop` parameter arrives via PyObjC as `None` for the `enumerateContactsWithFetchRequest:error:usingBlock:` selector — the [contacts-performance skill](.claude/skills/contacts-performance/SKILL.md)'s `stop_ptr[0] = True` snippet was wrong, and our unit-test fakes (which I wrote) encoded the assumed behavior, not the real one. **24 unit tests for the enumerate helper all passed.**

This is exactly the [OmniFocus story](.claude/skills/integration-testing/SKILL.md) the skill warns about — fixed in this PR + added a unit-level regression test passing `stop_ptr=None` so the pattern doesn't drift back.

Trade-off: lost the short-circuit optimization on this code path. The framework still walks all N contacts when limit < N; we just don't pay the dict-serialization cost past the limit. Gap-analysis baseline is 53ms for 1696 contacts, so the practical impact is negligible.

## Fixture lifecycle

- **`real_connector`** (session): handles TCC. Skips the session if status is `denied`/`restricted`; calls `_run_cn_request_access` when `notDetermined` (15s connector timeout for the user to click Allow in the system prompt).
- **`test_group`** (session): finds-or-creates the `MCP-Test` group via raw CN calls (group CRUD is v0.2.0+, so it lives in the conftest for now). Yields the CN identifier.
- **`integration_env`** (session): sets `CONTACTS_TEST_MODE=true` + `CONTACTS_TEST_GROUP=MCP-Test` so the destructive-op gates from #6/#13/#14 are armed.
- **`tmp_contact`** (function): creates a contact in the test group, yields the identifier, deletes on teardown (best-effort, doesn't mask test failures).
- **Session teardown**: enumerates every contact in the test group, deletes each, then deletes the group itself. Cleanup-on-next-run handles crashed sessions.

## Test files

- [tests/integration/conftest.py](tests/integration/conftest.py) — fixtures + raw CN helpers for group lifecycle.
- [tests/integration/test_authorization.py](tests/integration/test_authorization.py) — `_run_cn_authorization_status`, `_run_cn_request_access`.
- [tests/integration/test_read_path.py](tests/integration/test_read_path.py) — `_run_cn_enumerate_contacts`, `_run_cn_unified_contact`, `_run_cn_search_contacts`, `_run_cn_fetch_group`.
- [tests/integration/test_crud_path.py](tests/integration/test_crud_path.py) — `_run_cn_create_contact`, `_run_cn_update_contact`, `_run_cn_delete_contact`, plus a full-CRUD-cycle smoke test.

## Test plan

- [x] `make test` — 167 unit tests pass (one new regression test); 20 integration deselected
- [x] `make test-integration` — 20/20 pass against real Contacts.app on macOS 26
- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy strict clean
- [x] `make coverage` — 95.78% project-wide
- [x] `make check-all` — full gate green

CI: integration tests stay excluded via the existing `-m "not integration and not e2e and not benchmark"` filter — no CI changes needed.

## Out of scope (deferred)

- AppleScript boundary integration test → add when first v0.2.0 tool uses `_run_applescript`.
- Real `_run_cn_create_group` / `_run_cn_delete_group` connector helpers → v0.2.0+ (group CRUD).
- Performance benchmarks against real CN → v0.4.0.
- CI on a self-hosted macOS runner with a populated test fixture → v0.4.0+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)