### PR TITLE
release: v0.1.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,11 +1,14 @@
 # Apple Contacts MCP Server
 
-**Version:** v0.0.0
+**Version:** v0.1.0
 
-This repo is in **bootstrap phase**.
+v0.1.0 ships the seven core CRUD tools (`check_authorization`, `list_contacts`,
+`get_contact`, `search_contacts`, `create_contact`, `update_contact`,
+`delete_contact`). See [docs/reference/TOOLS.md](../docs/reference/TOOLS.md)
+for the API surface and [CHANGELOG.md](../CHANGELOG.md) for release notes.
 
-- Read `BOOTSTRAP.md` first if this is your first session in this repo.
 - `MCP_PLAYBOOK.md` is the authoritative project-agnostic reference.
+- `BOOTSTRAP.md` documents the initial repo setup (mostly historical now).
 - This file accrues contacts-specific guidance as the project grows.
 
 ## Phase 0 — API decision (2026-04-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.0] - 2026-05-06
+
+First feature release. Seven CRUD tools backed by `Contacts.framework` via PyObjC, gated by TCC authorization checks and test-mode safety.
+
+### Added
+
+- `check_authorization` — query the current TCC authorization status without triggering the system permission prompt. Returns `success: true` for every status (status-query semantics) with status-specific remediation copy when access is not granted (#9).
+- `list_contacts(offset, limit)` — paged read-only listing returning `{id, given_name, family_name, organization}` per entry. Default 50/page, hard cap 200 (#10).
+- `get_contact(identifier)` — full P1 contact dict including name parts, organization triplet, phones, emails, urls, postal addresses, and birthday. Each labeled-value entry carries both the raw Apple token (e.g. `_$!<Mobile>!$_`) and the localized string (`mobile`) (#11).
+- `search_contacts(query)` — substring/case-insensitive search via `predicateForContactsMatchingName:`. Same 4-field shape as `list_contacts`, hard cap 200 results (#12).
+- `create_contact(...)` — write via `CNMutableContact` + `CNSaveRequest.addContact:toContainerWithIdentifier:` to the user's default container. Optional `group_identifier` adds the new contact to a group atomically. Returns the new contact's CN identifier (#13).
+- `update_contact(identifier, ...)` — partial-field update with presence semantics (`None` = don't touch, `""` = explicitly clear). Multi-valued lists (phones / emails / urls / postal_addresses) follow REST-PUT replace semantics (#14).
+- `delete_contact(identifier)` — destructive delete via `CNSaveRequest.deleteContact:`. **v0.1.0 only allows delete in test mode**; the full destructive UX (with confirmation prompts) ships in v0.4.0 (#14, #24).
+- Test-mode safety gate (`CONTACTS_TEST_MODE` + `CONTACTS_TEST_GROUP`): destructive ops are constrained to a designated test group, and `delete_contact` is refused entirely outside test mode (#6, #14).
+- Mock-boundary helpers in `contacts_connector.py` (`_run_cn_*`, `_run_applescript`) so unit tests mock at the connector edge and integration tests hit real `CNContactStore` (#5).
+- Integration test rig under `tests/integration/` covering every `_run_cn_*` helper. Skip-by-default via `--run-integration` flag; session-scoped `MCP-Test` group fixture handles setup and cleanup against a real address book (#15).
+- API reference at [docs/reference/TOOLS.md](docs/reference/TOOLS.md) — every tool's signature, parameters, success/error response shapes, and error_type catalog (#8).
+- Phase 0 API gap analysis at `docs/research/contacts-api-gap-analysis.md` documenting the empirical basis for choosing `Contacts.framework` over AppleScript / JXA / vCard (#2).
+- Claude skills `contacts-framework` and `contacts-performance` capturing PyObjC bridging gotchas and per-tool perf baselines (#7).
+
+### Fixed
+
+- `_run_cn_enumerate_contacts` no longer crashes on real PyObjC: the `BOOL *stop` argument arrives as `None` for the `enumerateContactsWithFetchRequest:error:usingBlock:` selector. Caught by the integration test rig on its first run; defensively guarded the assignment and added a unit-level regression test (#15).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 A Model Context Protocol server for Apple Contacts on macOS.
 
-> **Status:** bootstrap phase. No tools shipped yet — see [BOOTSTRAP.md](BOOTSTRAP.md) and [INITIAL_ISSUES.md](INITIAL_ISSUES.md) (TBD) for the v0.1.0 roadmap. The first feature lands once Phase 0 API research is complete.
+**Version:** v0.1.0 — first feature release. Seven CRUD tools backed by `Contacts.framework` via PyObjC. See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for the API surface and [CHANGELOG.md](CHANGELOG.md) for release notes.
+
+## Tools
+
+- `check_authorization` — TCC status pre-flight.
+- `list_contacts` — paged read.
+- `get_contact` — full P1 fetch by identifier.
+- `search_contacts` — predicate by name.
+- `create_contact` — write via `CNSaveRequest`.
+- `update_contact` — partial-field update.
+- `delete_contact` — test-mode-only in v0.1.0; full destructive UX ships in v0.4.0.
 
 ## Install
 
@@ -14,7 +24,9 @@ uv sync --dev
 
 ## Usage
 
-TBD. The server entry point is registered as `apple-contacts-mcp` (see `pyproject.toml [project.scripts]`). Once tools land, configure in Claude Desktop's MCP settings.
+The server entry point is registered as `apple-contacts-mcp` (see `pyproject.toml [project.scripts]`). Configure it in Claude Desktop's MCP settings to expose the tool list above.
+
+First run will trigger the system TCC permission prompt. Grant access in System Settings → Privacy & Security → Contacts. See `check_authorization`'s response shape in [TOOLS.md](docs/reference/TOOLS.md#check_authorization) for the recovery flow if access was denied.
 
 ## Development
 

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -2,7 +2,7 @@
 
 Reference for every MCP tool the apple-contacts-mcp server exposes.
 
-**Version:** v0.0.0 (tracks the package version)
+**Version:** v0.1.0 (tracks the package version)
 **Tools:** 7
 
 The source-of-truth for tool behavior is the docstrings in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-contacts-mcp"
-version = "0.0.0"
+version = "0.1.0"
 description = "MCP server for Apple Contacts integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_contacts_mcp/__init__.py
+++ b/src/apple_contacts_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Contacts MCP Server.
 A Model Context Protocol server for Apple Contacts integration.
 """
 
-__version__ = "0.0.0"
+__version__ = "0.1.0"

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -12,7 +12,7 @@ from apple_contacts_mcp.security import sanitize_input
 
 
 def test_version() -> None:
-    assert __version__ == "0.0.0"
+    assert __version__ == "0.1.0"
 
 
 def test_connector_instantiates() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "apple-contacts-mcp"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
First feature release. Tags as **v0.1.0** after merge.

## Release contents

Seven CRUD tools backed by `Contacts.framework` via PyObjC, gated by TCC authorization checks and test-mode safety.

| Tool | Issue | Notes |
|---|---|---|
| `check_authorization` | #9 | TCC status query; always `success: true` |
| `list_contacts` | #10 | Paged read, hard cap 200/page |
| `get_contact` | #11 | Full P1 fetch by identifier |
| `search_contacts` | #12 | Predicate by name; cap 200 |
| `create_contact` | #13 | `CNSaveRequest` write; test-mode requires `group_identifier` |
| `update_contact` | #14 | Partial-field with presence semantics |
| `delete_contact` | #14 | Test-mode-only in v0.1.0; full UX in v0.4.0 (#24) |

Plus: connector mock boundary (#5), test-mode safety gate (#6), Phase 0 API gap analysis (#2), Claude skills (#7), API reference [TOOLS.md](docs/reference/TOOLS.md) (#8), and the integration test rig (#15) which caught a real PyObjC `stop_ptr=None` bug on its first run.

## Release-skill phases

- **1: Milestone check** — 0 open / 11 closed in v0.1.0.
- **2: Version** — confirmed `0.0.0 → 0.1.0`.
- **3: Branch** — `release/v0.1.0` from `main`.
- **4: Version bump** — pyproject, __init__, CLAUDE.md, README, TOOLS.md, smoke test. `check_version_sync.sh` clean.
- **5: CHANGELOG** — full v0.1.0 entry under Keep-a-Changelog.
- **6: Coverage** — 95.78% project-wide (gate 90%); 167 unit + 20 integration tests.
- **7: Code review** — `superpowers:code-reviewer` cross-cutting pass. No blockers. Recommendations for v0.2.0 noted in commit body.
- **8: Docs review** — TOOLS.md/CLAUDE.md/README updated; no leftover 0.0.0 references.
- **9: Validation gauntlet** — version-sync, changelog-date, client-server-parity, complexity, dependencies, readme-claims, `make test` — all green.

## Post-merge

- Tag `v0.1.0` on `main` via `./scripts/create_tag.sh v0.1.0` (Phase 11).
- Close v0.1.0 milestone (Phase 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)