### PR TITLE
feat: search_contacts — phone/email/organization (closes #16)

### DIFF
--- a/.claude/skills/contacts-framework/SKILL.md
+++ b/.claude/skills/contacts-framework/SKILL.md
@@ -119,6 +119,8 @@ results, err = store.unifiedContactsMatchingPredicate_keysToFetch_error_(
 
 For organization-name matching, there's no canned predicate — use a custom `NSPredicate`. Document the workaround as you write it.
 
+**Phone-predicate fetch-keys gotcha (undocumented):** `predicateForContactsMatchingPhoneNumber:` silently returns zero results unless `CNContactPhoneNumbersKey` is in `keysToFetch`. The unification step apparently skips contacts whose matching field wasn't requested. Empirically verified 2026-05-08 against macOS 14 + a contact created and immediately searched in the same store. Email currently matches without `CNContactEmailAddressesKey` but include it anyway for symmetry — Apple may tighten the rule. Bottom line: when filtering by a multi-valued field, always include that field's storage key in `keysToFetch`.
+
 ## Writes — `CNSaveRequest`
 
 Mutations go through `CNSaveRequest`. Build the request, then submit it once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `search_contacts` — phone, email, and organization predicate modes alongside the existing name search. Phone matching uses Apple's format-tolerant `predicateForContactsMatchingPhoneNumber:` (with `CNPhoneNumber` wrapping); email uses `predicateForContactsMatchingEmailAddress:`; organization uses a custom `CONTAINS[cd]` `NSPredicate` to mirror name-mode case- and diacritic-insensitive substring behavior (#16).
+
+### Changed
+
+- `search_contacts` signature: `query: str` is replaced by four mutually-exclusive parameters (`name`, `phone`, `email`, `organization`). Exactly one must be set; whitespace-only counts as unset. **Breaking change** vs v0.1.0 (#16).
+- `search_contacts` success response: the `query` key is replaced by flat `search_field` + `search_value` keys. `search_value` echoes the stripped value (#16).
+
 ## [0.1.0] - 2026-05-06
 
 First feature release. Seven CRUD tools backed by `Contacts.framework` via PyObjC, gated by TCC authorization checks and test-mode safety.

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -195,17 +195,25 @@ When the identifier doesn't resolve:
 
 ### search_contacts
 
-Find contacts whose name matches `query` (substring, case-insensitive).
+Find contacts by name, phone, email, or organization (pick one).
 
 ```python
-def search_contacts(query: str) -> dict[str, Any]
+def search_contacts(
+    name: str = "",
+    phone: str = "",
+    email: str = "",
+    organization: str = "",
+) -> dict[str, Any]
 ```
 
-**Parameters:**
+**Parameters:** exactly one must be set (non-empty after stripping); whitespace-only counts as unset.
 
 | Name | Type | Default | Description |
 |---|---|---|---|
-| `query` | str | — | Substring to match. Must be a non-empty string (the empty string would silently return all contacts in CN's predicate; we reject it). |
+| `name` | str | `""` | Substring to match against given/family/organization names. |
+| `phone` | str | `""` | Phone number to match (any format). |
+| `email` | str | `""` | Email address to match. |
+| `organization` | str | `""` | Substring to match against organization name. |
 
 **Returns:**
 
@@ -216,7 +224,8 @@ def search_contacts(query: str) -> dict[str, Any]
     {"id": "ABCD-…", "given_name": "John", "family_name": "Smith", "organization": "Acme"}
   ],
   "count": 28,
-  "query": "john",
+  "search_field": "name",
+  "search_value": "john",
   "limit": 200
 }
 ```
@@ -224,11 +233,16 @@ def search_contacts(query: str) -> dict[str, Any]
 **Error types:** `validation_error`, `authorization_denied`, `unknown`.
 
 **Notes:**
-- Matches given/family/organization names via Apple's built-in `predicateForContactsMatchingName:` — substring, case-insensitive.
+- Setting zero or multiple fields returns `validation_error`. The error message lists the fields involved.
+- `search_value` echoes the **stripped** value the predicate actually saw.
+- Match semantics per field:
+  - `name`: substring + case-insensitive across given/family/organization names (Apple's `predicateForContactsMatchingName:`).
+  - `phone`: format-tolerant via Apple's `predicateForContactsMatchingPhoneNumber:` — punctuation, spacing, and country-code variants normalize, so `(555) 123-4567` and `+15551234567` match the same contact.
+  - `email`: Apple's `predicateForContactsMatchingEmailAddress:`.
+  - `organization`: substring, case- and diacritic-insensitive (custom `NSPredicate` with `CONTAINS[cd]`), since Apple ships no built-in organization predicate. Mirrors name-mode behavior.
 - Hard cap at **200 results**. `count == limit` indicates the cap was hit and there may be more matches; narrow the query.
 - Returns the same 4-field shape as `list_contacts`. Use `get_contact(id)` to fetch full details for a specific result.
 - Order is not guaranteed.
-- Phone / email / organization predicate variants land in v0.2.0 (issue #12 in INITIAL_ISSUES.md).
 
 ---
 

--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -13,7 +13,7 @@ import logging
 import subprocess
 import threading
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from .exceptions import (
     ContactsAppleScriptError,
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
     from Contacts import CNContactStore  # pragma: no cover
 
 logger = logging.getLogger(__name__)
+
+SearchField = Literal["name", "phone", "email", "organization"]
+
 
 _CN_AUTHORIZATION_STATUS: dict[int, str] = {
     0: "notDetermined",
@@ -319,9 +322,22 @@ class ContactsConnector:
         return identifier
 
     def _run_cn_search_contacts(
-        self, query: str, limit: int
+        self, *, field: SearchField, value: str, limit: int
     ) -> list[dict[str, str]]:
-        """Search contacts by name predicate, returning basic-field dicts.
+        """Search contacts by ``field`` predicate, returning basic-field dicts.
+
+        ``field`` selects the predicate:
+
+        - ``"name"``: ``predicateForContactsMatchingName:`` (substring,
+          case-insensitive across given/family/organization names).
+        - ``"phone"``: ``predicateForContactsMatchingPhoneNumber:`` after
+          wrapping ``value`` in a ``CNPhoneNumber``. Apple's matcher is
+          format-tolerant — punctuation and country-code variants normalize.
+        - ``"email"``: ``predicateForContactsMatchingEmailAddress:``.
+        - ``"organization"``: hand-rolled ``NSPredicate`` with
+          ``CONTAINS[cd]`` on ``organizationName`` (case- and
+          diacritic-insensitive substring), to mirror name-mode semantics
+          since Apple ships no built-in organization predicate.
 
         Predicate execution is offloaded to the framework — fast even on
         large address books. We slice to ``limit`` *while serializing*
@@ -341,7 +357,28 @@ class ContactsConnector:
             CNContactFamilyNameKey,
             CNContactOrganizationNameKey,
         ]
-        pred = CNContact.predicateForContactsMatchingName_(query)
+        match field:
+            case "name":
+                pred = CNContact.predicateForContactsMatchingName_(value)
+            case "phone":
+                from Contacts import CNPhoneNumber
+
+                pred = CNContact.predicateForContactsMatchingPhoneNumber_(
+                    CNPhoneNumber.phoneNumberWithStringValue_(value)
+                )
+            case "email":
+                pred = CNContact.predicateForContactsMatchingEmailAddress_(
+                    value
+                )
+            case "organization":
+                from Foundation import NSPredicate
+
+                pred = NSPredicate.predicateWithFormat_(
+                    "organizationName CONTAINS[cd] %@", value
+                )
+            case _:
+                raise ContactsError(f"Unknown search field: {field!r}")
+
         store = self._get_store()
         results, err = store.unifiedContactsMatchingPredicate_keysToFetch_error_(
             pred, keys, None

--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -345,10 +345,12 @@ class ContactsConnector:
         """
         from Contacts import (
             CNContact,
+            CNContactEmailAddressesKey,
             CNContactFamilyNameKey,
             CNContactGivenNameKey,
             CNContactIdentifierKey,
             CNContactOrganizationNameKey,
+            CNContactPhoneNumbersKey,
         )
 
         keys = [
@@ -363,10 +365,19 @@ class ContactsConnector:
             case "phone":
                 from Contacts import CNPhoneNumber
 
+                # Apple's phone predicate silently returns zero results if
+                # CNContactPhoneNumbersKey isn't in keysToFetch — the
+                # unification step skips contacts whose matching field
+                # wasn't requested. Empirically verified; not documented.
+                keys.append(CNContactPhoneNumbersKey)
                 pred = CNContact.predicateForContactsMatchingPhoneNumber_(
                     CNPhoneNumber.phoneNumberWithStringValue_(value)
                 )
             case "email":
+                # Email predicate currently matches without
+                # CNContactEmailAddressesKey, but include it for symmetry
+                # with phone in case Apple tightens the unification step.
+                keys.append(CNContactEmailAddressesKey)
                 pred = CNContact.predicateForContactsMatchingEmailAddress_(
                     value
                 )

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from fastmcp import FastMCP
 
-from .contacts_connector import ContactsConnector
+from .contacts_connector import ContactsConnector, SearchField
 from .exceptions import ContactsNotFoundError, ContactsTimeoutError
 from .security import check_test_mode_safety, require_test_mode_for
 
@@ -245,35 +245,69 @@ def get_contact(identifier: str) -> dict[str, Any]:
 
 
 @mcp.tool()
-def search_contacts(query: str) -> dict[str, Any]:
-    """Find contacts whose name matches `query` (substring, case-insensitive).
+def search_contacts(
+    name: str = "",
+    phone: str = "",
+    email: str = "",
+    organization: str = "",
+) -> dict[str, Any]:
+    """Find contacts by name, phone, email, or organization (pick one).
 
-    Matches given/family/organization names via Apple's built-in
-    ``predicateForContactsMatchingName:``. Returns up to 200 results
-    (hard cap). Use ``list_contacts`` for unfiltered iteration;
-    ``get_contact(id)`` for full details on a specific result. Order
-    is not guaranteed.
+    Exactly one of the four parameters must be set (non-empty after
+    stripping); whitespace-only values count as unset. Returns up to
+    200 results (hard cap). Use ``list_contacts`` for unfiltered
+    iteration; ``get_contact(id)`` for full details on a result.
+    Order is not guaranteed.
+
+    Match semantics:
+
+    - ``name``: substring + case-insensitive across given/family/
+      organization names (Apple's ``predicateForContactsMatchingName:``).
+    - ``phone``: format-tolerant match via Apple's
+      ``predicateForContactsMatchingPhoneNumber:``. Punctuation,
+      spacing, and country-code variants normalize automatically; pass
+      whatever the user typed.
+    - ``email``: ``predicateForContactsMatchingEmailAddress:``.
+    - ``organization``: substring, case- and diacritic-insensitive
+      (custom ``NSPredicate`` with ``CONTAINS[cd]``), to mirror
+      name-mode behavior since Apple ships no built-in organization
+      predicate.
 
     Args:
-        query: Substring to match. Must be a non-empty string.
+        name: Substring to match against contact names.
+        phone: Phone number to match (any format).
+        email: Email address to match.
+        organization: Substring to match against organization name.
 
     Returns:
         On success: ``{"success": True, "contacts": [...], "count": N,
-        "query": query, "limit": 200}``. ``count == limit`` indicates
-        the cap was hit and there may be more matches.
-        On bad input: ``{"success": False, "error_type":
-        "validation_error", "error": ...}``.
+        "search_field": "<name|phone|email|organization>",
+        "search_value": "<stripped value>", "limit": 200}``.
+        ``count == limit`` indicates the cap was hit and there may be
+        more matches.
+        On bad input (zero or multiple fields set): ``{"success":
+        False, "error_type": "validation_error", "error": ...}``.
         On TCC denial: same shape as ``list_contacts`` (status,
         remediation).
         On unexpected failure: ``{"success": False, "error_type":
         "unknown", "error": ...}``.
     """
-    if not query or not query.strip():
-        return {
-            "success": False,
-            "error": "query must be a non-empty string",
-            "error_type": "validation_error",
-        }
+    candidates = {
+        "name": name,
+        "phone": phone,
+        "email": email,
+        "organization": organization,
+    }
+    provided = {k: v.strip() for k, v in candidates.items() if v.strip()}
+    if len(provided) == 0:
+        return _validation_error(
+            "Exactly one of name, phone, email, organization must be set."
+        )
+    if len(provided) > 1:
+        return _validation_error(
+            f"Exactly one search field allowed; got {sorted(provided)}."
+        )
+    [(field, value)] = provided.items()
 
     auth_err = _require_contacts_authorization()
     if auth_err is not None:
@@ -281,7 +315,9 @@ def search_contacts(query: str) -> dict[str, Any]:
 
     try:
         contacts = connector._run_cn_search_contacts(
-            query=query, limit=_SEARCH_CONTACTS_MAX
+            field=cast(SearchField, field),
+            value=value,
+            limit=_SEARCH_CONTACTS_MAX,
         )
     except Exception as exc:
         logger.error("search_contacts fetch failed: %s", exc)
@@ -295,7 +331,8 @@ def search_contacts(query: str) -> dict[str, Any]:
         "success": True,
         "contacts": contacts,
         "count": len(contacts),
-        "query": query,
+        "search_field": field,
+        "search_value": value,
         "limit": _SEARCH_CONTACTS_MAX,
     }
 

--- a/tests/integration/test_read_path.py
+++ b/tests/integration/test_read_path.py
@@ -129,9 +129,10 @@ def test_search_finds_contact_by_unique_phone(
 ) -> None:
     """A contact created with a unique phone number is findable via Apple's
     phone predicate, which normalizes punctuation and country codes."""
-    # 14-digit suffix gives an effectively unique number against any
-    # real address book; the leading +1 makes Apple parse it as US E.164.
-    unique_phone = f"+1555{uuid.uuid4().int % 10**10:010d}"
+    # Valid US E.164: +1 + 10-digit subscriber. The 555 area code with a
+    # 7-digit random suffix gives ~10M possibilities — effectively unique
+    # against any real address book and won't trip Apple's length check.
+    unique_phone = f"+1555{uuid.uuid4().int % 10**7:07d}"
     identifier = real_connector._run_cn_create_contact(
         fields={
             "given_name": "PhoneSearch",

--- a/tests/integration/test_read_path.py
+++ b/tests/integration/test_read_path.py
@@ -103,7 +103,7 @@ def test_search_finds_contact_by_unique_name(
     )
     try:
         results = real_connector._run_cn_search_contacts(
-            query=unique_token, limit=10
+            field="name", value=unique_token, limit=10
         )
         ids = {entry["id"] for entry in results}
         assert identifier in ids
@@ -116,7 +116,87 @@ def test_search_no_match_returns_empty(
 ) -> None:
     """A query guaranteed to miss returns an empty list."""
     impossible = f"NoSuchPerson-{uuid.uuid4().hex}"
-    assert real_connector._run_cn_search_contacts(query=impossible, limit=10) == []
+    assert (
+        real_connector._run_cn_search_contacts(
+            field="name", value=impossible, limit=10
+        )
+        == []
+    )
+
+
+def test_search_finds_contact_by_unique_phone(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """A contact created with a unique phone number is findable via Apple's
+    phone predicate, which normalizes punctuation and country codes."""
+    # 14-digit suffix gives an effectively unique number against any
+    # real address book; the leading +1 makes Apple parse it as US E.164.
+    unique_phone = f"+1555{uuid.uuid4().int % 10**10:010d}"
+    identifier = real_connector._run_cn_create_contact(
+        fields={
+            "given_name": "PhoneSearch",
+            "family_name": "Fixture",
+            "phones": [{"label_raw": "_$!<Mobile>!$_", "value": unique_phone}],
+        },
+        group_identifier=test_group,
+    )
+    try:
+        results = real_connector._run_cn_search_contacts(
+            field="phone", value=unique_phone, limit=10
+        )
+        ids = {entry["id"] for entry in results}
+        assert identifier in ids
+    finally:
+        real_connector._run_cn_delete_contact(identifier)
+
+
+def test_search_finds_contact_by_unique_email(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """A contact created with a unique email is findable via the email
+    predicate. Uses the .invalid TLD so the address can never collide."""
+    unique_email = f"integ-{uuid.uuid4().hex}@mcp-test.invalid"
+    identifier = real_connector._run_cn_create_contact(
+        fields={
+            "given_name": "EmailSearch",
+            "family_name": "Fixture",
+            "emails": [{"label_raw": "_$!<Work>!$_", "value": unique_email}],
+        },
+        group_identifier=test_group,
+    )
+    try:
+        results = real_connector._run_cn_search_contacts(
+            field="email", value=unique_email, limit=10
+        )
+        ids = {entry["id"] for entry in results}
+        assert identifier in ids
+    finally:
+        real_connector._run_cn_delete_contact(identifier)
+
+
+def test_search_finds_contact_by_unique_organization(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """A contact created with a unique organization name is findable via
+    the custom CONTAINS[cd] NSPredicate, exercising the org-mode path that
+    has no built-in Apple predicate."""
+    unique_org = f"MCP-Test-{uuid.uuid4().hex[:12]}"
+    identifier = real_connector._run_cn_create_contact(
+        fields={
+            "given_name": "OrgSearch",
+            "family_name": "Fixture",
+            "organization": unique_org,
+        },
+        group_identifier=test_group,
+    )
+    try:
+        results = real_connector._run_cn_search_contacts(
+            field="organization", value=unique_org, limit=10
+        )
+        ids = {entry["id"] for entry in results}
+        assert identifier in ids
+    finally:
+        real_connector._run_cn_delete_contact(identifier)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -763,11 +763,13 @@ def _install_fake_contacts_for_search(
     monkeypatch: pytest.MonkeyPatch,
     results: list[MagicMock] | None,
     fake_error: object | None = None,
-) -> tuple[MagicMock, MagicMock]:
-    """Install a fake `Contacts` module + a store whose
-    unifiedContactsMatchingPredicate... returns (results, fake_error).
+) -> tuple[MagicMock, MagicMock, MagicMock, MagicMock]:
+    """Install fake ``Contacts`` + ``Foundation`` modules + a store whose
+    unifiedContactsMatchingPredicate... returns ``(results, fake_error)``.
 
-    Returns (CNContact_class_mock, store_instance_mock) for assertions.
+    Returns ``(CNContact_class_mock, store_instance_mock,
+    CNPhoneNumber_class_mock, NSPredicate_class_mock)`` for per-mode
+    predicate assertions.
     """
     fake_module = types.ModuleType("Contacts")
     fake_module.CNContactIdentifierKey = "id_key"  # type: ignore[attr-defined]
@@ -776,9 +778,23 @@ def _install_fake_contacts_for_search(
     fake_module.CNContactOrganizationNameKey = "org_key"  # type: ignore[attr-defined]
 
     cn_contact_class = MagicMock(name="CNContact")
-    pred_stub = MagicMock(name="NSPredicate")
-    cn_contact_class.predicateForContactsMatchingName_.return_value = pred_stub
+    name_pred = MagicMock(name="NamePredicate")
+    phone_pred = MagicMock(name="PhonePredicate")
+    email_pred = MagicMock(name="EmailPredicate")
+    cn_contact_class.predicateForContactsMatchingName_.return_value = name_pred
+    cn_contact_class.predicateForContactsMatchingPhoneNumber_.return_value = (
+        phone_pred
+    )
+    cn_contact_class.predicateForContactsMatchingEmailAddress_.return_value = (
+        email_pred
+    )
     fake_module.CNContact = cn_contact_class  # type: ignore[attr-defined]
+
+    cn_phone_number_class = MagicMock(name="CNPhoneNumber")
+    cn_phone_number_class.phoneNumberWithStringValue_.return_value = MagicMock(
+        name="CNPhoneNumberInstance"
+    )
+    fake_module.CNPhoneNumber = cn_phone_number_class  # type: ignore[attr-defined]
 
     cn_store_class = MagicMock(name="CNContactStore")
     store_instance = MagicMock(name="store_instance")
@@ -790,7 +806,16 @@ def _install_fake_contacts_for_search(
     fake_module.CNContactStore = cn_store_class  # type: ignore[attr-defined]
 
     monkeypatch.setitem(sys.modules, "Contacts", fake_module)
-    return cn_contact_class, store_instance
+
+    fake_foundation = types.ModuleType("Foundation")
+    ns_predicate_class = MagicMock(name="NSPredicate")
+    ns_predicate_class.predicateWithFormat_.return_value = MagicMock(
+        name="OrgPredicate"
+    )
+    fake_foundation.NSPredicate = ns_predicate_class  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "Foundation", fake_foundation)
+
+    return cn_contact_class, store_instance, cn_phone_number_class, ns_predicate_class
 
 
 def test_search_returns_empty_when_no_matches(
@@ -798,7 +823,10 @@ def test_search_returns_empty_when_no_matches(
 ) -> None:
     _install_fake_contacts_for_search(monkeypatch, results=[])
     connector = ContactsConnector()
-    assert connector._run_cn_search_contacts(query="nobody", limit=200) == []
+    assert (
+        connector._run_cn_search_contacts(field="name", value="nobody", limit=200)
+        == []
+    )
 
 
 def test_search_returns_dicts_for_each_match(
@@ -810,7 +838,9 @@ def test_search_returns_dicts_for_each_match(
     ]
     _install_fake_contacts_for_search(monkeypatch, results=fakes)
     connector = ContactsConnector()
-    result = connector._run_cn_search_contacts(query="john", limit=200)
+    result = connector._run_cn_search_contacts(
+        field="name", value="john", limit=200
+    )
     assert result == [
         {"id": "id-0", "given_name": "John", "family_name": "Smith", "organization": "Acme"},
         {"id": "id-1", "given_name": "Johnny", "family_name": "Walker", "organization": ""},
@@ -823,7 +853,9 @@ def test_search_caps_results_at_limit_and_skips_serializing_extras(
     fakes = [_make_basic_contact(f"id-{i}") for i in range(250)]
     _install_fake_contacts_for_search(monkeypatch, results=fakes)
     connector = ContactsConnector()
-    result = connector._run_cn_search_contacts(query="x", limit=200)
+    result = connector._run_cn_search_contacts(
+        field="name", value="x", limit=200
+    )
     assert len(result) == 200
     assert result[0]["id"] == "id-0"
     assert result[-1]["id"] == "id-199"
@@ -831,15 +863,94 @@ def test_search_caps_results_at_limit_and_skips_serializing_extras(
     assert fakes[200].identifier.call_count == 0
 
 
-def test_search_calls_predicate_with_query(
+def test_search_name_calls_name_predicate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    cn_contact_class, _ = _install_fake_contacts_for_search(monkeypatch, results=[])
+    cn_contact_class, _, cn_phone_number_class, ns_predicate_class = (
+        _install_fake_contacts_for_search(monkeypatch, results=[])
+    )
     connector = ContactsConnector()
-    connector._run_cn_search_contacts(query="alice", limit=200)
+    connector._run_cn_search_contacts(field="name", value="alice", limit=200)
     cn_contact_class.predicateForContactsMatchingName_.assert_called_once_with(
         "alice"
     )
+    cn_contact_class.predicateForContactsMatchingPhoneNumber_.assert_not_called()
+    cn_contact_class.predicateForContactsMatchingEmailAddress_.assert_not_called()
+    cn_phone_number_class.phoneNumberWithStringValue_.assert_not_called()
+    ns_predicate_class.predicateWithFormat_.assert_not_called()
+
+
+def test_search_phone_wraps_value_in_cn_phone_number(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cn_contact_class, _, cn_phone_number_class, ns_predicate_class = (
+        _install_fake_contacts_for_search(monkeypatch, results=[])
+    )
+    connector = ContactsConnector()
+    connector._run_cn_search_contacts(
+        field="phone", value="+15551234567", limit=200
+    )
+    cn_phone_number_class.phoneNumberWithStringValue_.assert_called_once_with(
+        "+15551234567"
+    )
+    wrapped = cn_phone_number_class.phoneNumberWithStringValue_.return_value
+    cn_contact_class.predicateForContactsMatchingPhoneNumber_.assert_called_once_with(
+        wrapped
+    )
+    cn_contact_class.predicateForContactsMatchingName_.assert_not_called()
+    cn_contact_class.predicateForContactsMatchingEmailAddress_.assert_not_called()
+    ns_predicate_class.predicateWithFormat_.assert_not_called()
+
+
+def test_search_email_calls_email_predicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cn_contact_class, _, cn_phone_number_class, ns_predicate_class = (
+        _install_fake_contacts_for_search(monkeypatch, results=[])
+    )
+    connector = ContactsConnector()
+    connector._run_cn_search_contacts(
+        field="email", value="alice@example.com", limit=200
+    )
+    cn_contact_class.predicateForContactsMatchingEmailAddress_.assert_called_once_with(
+        "alice@example.com"
+    )
+    cn_contact_class.predicateForContactsMatchingName_.assert_not_called()
+    cn_contact_class.predicateForContactsMatchingPhoneNumber_.assert_not_called()
+    cn_phone_number_class.phoneNumberWithStringValue_.assert_not_called()
+    ns_predicate_class.predicateWithFormat_.assert_not_called()
+
+
+def test_search_organization_uses_contains_cd_nspredicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cn_contact_class, _, cn_phone_number_class, ns_predicate_class = (
+        _install_fake_contacts_for_search(monkeypatch, results=[])
+    )
+    connector = ContactsConnector()
+    connector._run_cn_search_contacts(
+        field="organization", value="acme", limit=200
+    )
+    ns_predicate_class.predicateWithFormat_.assert_called_once_with(
+        "organizationName CONTAINS[cd] %@", "acme"
+    )
+    cn_contact_class.predicateForContactsMatchingName_.assert_not_called()
+    cn_contact_class.predicateForContactsMatchingPhoneNumber_.assert_not_called()
+    cn_contact_class.predicateForContactsMatchingEmailAddress_.assert_not_called()
+    cn_phone_number_class.phoneNumberWithStringValue_.assert_not_called()
+
+
+def test_search_unknown_field_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_contacts_for_search(monkeypatch, results=[])
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError):
+        connector._run_cn_search_contacts(
+            field="bogus",  # type: ignore[arg-type]
+            value="x",
+            limit=200,
+        )
 
 
 def test_search_dict_keys_are_exactly_the_four_basic_fields(
@@ -849,7 +960,9 @@ def test_search_dict_keys_are_exactly_the_four_basic_fields(
         monkeypatch, results=[_make_basic_contact("id-0", "A", "B", "C")]
     )
     connector = ContactsConnector()
-    [entry] = connector._run_cn_search_contacts(query="a", limit=200)
+    [entry] = connector._run_cn_search_contacts(
+        field="name", value="a", limit=200
+    )
     assert set(entry.keys()) == {"id", "given_name", "family_name", "organization"}
 
 
@@ -863,7 +976,7 @@ def test_search_raises_contacts_error_when_results_is_none(
     )
     connector = ContactsConnector()
     with pytest.raises(ContactsError) as exc_info:
-        connector._run_cn_search_contacts(query="x", limit=200)
+        connector._run_cn_search_contacts(field="name", value="x", limit=200)
     assert "boom" in str(exc_info.value)
 
 

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -776,6 +776,8 @@ def _install_fake_contacts_for_search(
     fake_module.CNContactGivenNameKey = "given_key"  # type: ignore[attr-defined]
     fake_module.CNContactFamilyNameKey = "family_key"  # type: ignore[attr-defined]
     fake_module.CNContactOrganizationNameKey = "org_key"  # type: ignore[attr-defined]
+    fake_module.CNContactPhoneNumbersKey = "phones_key"  # type: ignore[attr-defined]
+    fake_module.CNContactEmailAddressesKey = "emails_key"  # type: ignore[attr-defined]
 
     cn_contact_class = MagicMock(name="CNContact")
     name_pred = MagicMock(name="NamePredicate")
@@ -951,6 +953,53 @@ def test_search_unknown_field_raises(
             value="x",
             limit=200,
         )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "required_key"),
+    [
+        ("phone", "+15551234567", "phones_key"),
+        ("email", "alice@example.com", "emails_key"),
+    ],
+)
+def test_search_includes_matched_field_in_keys_to_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: str,
+    required_key: str,
+) -> None:
+    """Apple's phone predicate silently returns zero results unless
+    CNContactPhoneNumbersKey is in keysToFetch. We empirically guard the
+    same invariant for email even though it currently matches without."""
+    _, store_instance, _, _ = _install_fake_contacts_for_search(
+        monkeypatch, results=[]
+    )
+    connector = ContactsConnector()
+    connector._run_cn_search_contacts(field=field, value=value, limit=200)  # type: ignore[arg-type]
+    (
+        _pred,
+        keys,
+        _err,
+    ) = store_instance.unifiedContactsMatchingPredicate_keysToFetch_error_.call_args.args
+    assert required_key in keys
+
+
+def test_search_name_keys_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Name search doesn't need any extra keys — the basic 4 are enough."""
+    _, store_instance, _, _ = _install_fake_contacts_for_search(
+        monkeypatch, results=[]
+    )
+    connector = ContactsConnector()
+    connector._run_cn_search_contacts(field="name", value="alice", limit=200)
+    (
+        _pred,
+        keys,
+        _err,
+    ) = store_instance.unifiedContactsMatchingPredicate_keysToFetch_error_.call_args.args
+    assert "phones_key" not in keys
+    assert "emails_key" not in keys
 
 
 def test_search_dict_keys_are_exactly_the_four_basic_fields(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -337,71 +337,168 @@ _FAKE_SEARCH_HITS = [
 ]
 
 
+_SEARCH_FIELDS = ("name", "phone", "email", "organization")
+_SEARCH_VALUES = {
+    "name": "alice",
+    "phone": "+15551234567",
+    "email": "alice@example.com",
+    "organization": "acme",
+}
+
+
 class TestSearchContactsValidation:
-    @pytest.mark.parametrize("query", ["", "   ", "\t", "\n  \t"])
-    def test_blank_query_returns_validation_error(self, query: str) -> None:
+    def test_no_fields_set_returns_validation_error(self) -> None:
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            result = search_contacts(query)
+            result = search_contacts()
         assert result["success"] is False
         assert result["error_type"] == "validation_error"
-        assert "query" in result["error"]
+        assert "name" in result["error"]
+        assert "phone" in result["error"]
+        assert "email" in result["error"]
+        assert "organization" in result["error"]
         mock_connector._run_cn_authorization_status.assert_not_called()
         mock_connector._run_cn_search_contacts.assert_not_called()
 
+    @pytest.mark.parametrize("blank", ["", "   ", "\t", "\n  \t"])
+    def test_only_whitespace_treated_as_unset(self, blank: str) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = search_contacts(name=blank)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_search_contacts.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "pair",
+        [
+            ("name", "phone"),
+            ("name", "email"),
+            ("name", "organization"),
+            ("phone", "email"),
+            ("phone", "organization"),
+            ("email", "organization"),
+        ],
+    )
+    def test_two_fields_set_returns_validation_error(
+        self, pair: tuple[str, str]
+    ) -> None:
+        kwargs = {f: _SEARCH_VALUES[f] for f in pair}
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = search_contacts(**kwargs)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        for f in pair:
+            assert f in result["error"]
+        mock_connector._run_cn_search_contacts.assert_not_called()
+
+    def test_all_four_fields_set_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = search_contacts(**_SEARCH_VALUES)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_search_contacts.assert_not_called()
+
+    def test_whitespace_on_others_does_not_count_as_set(self) -> None:
+        """name='alice' alongside phone='   ' is a single-field call."""
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = (
+                "authorized"
+            )
+            mock_connector._run_cn_search_contacts.return_value = []
+            result = search_contacts(
+                name="alice", phone="   ", email="\t", organization=""
+            )
+        assert result["success"] is True
+        mock_connector._run_cn_search_contacts.assert_called_once_with(
+            field="name", value="alice", limit=200
+        )
+
 
 class TestSearchContactsAuthFlow:
-    def test_auth_denied_passthrough_skips_search(self) -> None:
+    @pytest.mark.parametrize("field", _SEARCH_FIELDS)
+    def test_auth_denied_passthrough_skips_search(self, field: str) -> None:
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
             mock_connector._run_cn_authorization_status.return_value = "denied"
-            result = search_contacts("john")
+            result = search_contacts(**{field: _SEARCH_VALUES[field]})
         assert result["success"] is False
         assert result["error_type"] == "authorization_denied"
         mock_connector._run_cn_search_contacts.assert_not_called()
 
 
 class TestSearchContactsHappyPath:
-    def test_returns_results_with_query_and_limit_echoed(self) -> None:
+    @pytest.mark.parametrize("field", _SEARCH_FIELDS)
+    def test_returns_results_with_search_field_and_value_echoed(
+        self, field: str
+    ) -> None:
+        value = _SEARCH_VALUES[field]
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            mock_connector._run_cn_authorization_status.return_value = "authorized"
-            mock_connector._run_cn_search_contacts.return_value = _FAKE_SEARCH_HITS
-            result = search_contacts("john")
+            mock_connector._run_cn_authorization_status.return_value = (
+                "authorized"
+            )
+            mock_connector._run_cn_search_contacts.return_value = (
+                _FAKE_SEARCH_HITS
+            )
+            result = search_contacts(**{field: value})
         assert result == {
             "success": True,
             "contacts": _FAKE_SEARCH_HITS,
             "count": 3,
-            "query": "john",
+            "search_field": field,
+            "search_value": value,
             "limit": 200,
         }
 
     def test_response_keys_are_minimal_on_success(self) -> None:
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            mock_connector._run_cn_authorization_status.return_value = "authorized"
-            mock_connector._run_cn_search_contacts.return_value = _FAKE_SEARCH_HITS
-            result = search_contacts("john")
+            mock_connector._run_cn_authorization_status.return_value = (
+                "authorized"
+            )
+            mock_connector._run_cn_search_contacts.return_value = (
+                _FAKE_SEARCH_HITS
+            )
+            result = search_contacts(name="john")
         assert set(result.keys()) == {
             "success",
             "contacts",
             "count",
-            "query",
+            "search_field",
+            "search_value",
             "limit",
         }
 
     def test_no_matches_returns_empty_list(self) -> None:
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_authorization_status.return_value = (
+                "authorized"
+            )
             mock_connector._run_cn_search_contacts.return_value = []
-            result = search_contacts("zzz-no-match")
+            result = search_contacts(name="zzz-no-match")
         assert result["success"] is True
         assert result["count"] == 0
         assert result["contacts"] == []
 
-    def test_connector_called_with_query_and_cap(self) -> None:
+    @pytest.mark.parametrize("field", _SEARCH_FIELDS)
+    def test_connector_called_with_field_value_and_cap(self, field: str) -> None:
+        value = _SEARCH_VALUES[field]
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_authorization_status.return_value = (
+                "authorized"
+            )
             mock_connector._run_cn_search_contacts.return_value = []
-            search_contacts("alice")
+            search_contacts(**{field: value})
         mock_connector._run_cn_search_contacts.assert_called_once_with(
-            query="alice", limit=200
+            field=field, value=value, limit=200
+        )
+
+    def test_search_value_is_stripped(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = (
+                "authorized"
+            )
+            mock_connector._run_cn_search_contacts.return_value = []
+            result = search_contacts(name="  alice  ")
+        assert result["search_value"] == "alice"
+        mock_connector._run_cn_search_contacts.assert_called_once_with(
+            field="name", value="alice", limit=200
         )
 
 
@@ -412,9 +509,11 @@ class TestSearchContactsCapDetection:
             for i in range(200)
         ]
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_authorization_status.return_value = (
+                "authorized"
+            )
             mock_connector._run_cn_search_contacts.return_value = cap_hit
-            result = search_contacts("j")
+            result = search_contacts(name="j")
         assert result["count"] == 200
         assert result["limit"] == 200
         assert result["count"] == result["limit"]
@@ -423,9 +522,13 @@ class TestSearchContactsCapDetection:
 class TestSearchContactsConnectorRaises:
     def test_unexpected_exception_returns_unknown_error(self) -> None:
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            mock_connector._run_cn_authorization_status.return_value = "authorized"
-            mock_connector._run_cn_search_contacts.side_effect = ContactsError("boom")
-            result = search_contacts("alice")
+            mock_connector._run_cn_authorization_status.return_value = (
+                "authorized"
+            )
+            mock_connector._run_cn_search_contacts.side_effect = ContactsError(
+                "boom"
+            )
+            result = search_contacts(name="alice")
         assert result["success"] is False
         assert result["error_type"] == "unknown"
         assert "boom" in result["error"]


### PR DESCRIPTION
## Summary

- Replace `search_contacts(query: str)` with four mutually-exclusive params (`name`, `phone`, `email`, `organization`); validate exactly one is set after stripping (whitespace-only counts as unset).
- Phone wraps via `CNPhoneNumber` and uses Apple's format-tolerant `predicateForContactsMatchingPhoneNumber:`; email uses `predicateForContactsMatchingEmailAddress:`; organization uses a hand-rolled `CONTAINS[cd]` `NSPredicate` (Apple ships no built-in organization predicate; `CONTAINS[cd]` mirrors name-mode case- and diacritic-insensitive substring behavior).
- Response shape: drop `query`, add flat `search_field` + `search_value`. Breaking vs v0.1.0; tracked under `### Changed` in the `[Unreleased]` block. Pre-1.0, so semver-clean.

## Notable gotcha discovered & fixed

Integration testing surfaced an undocumented Apple constraint: `predicateForContactsMatchingPhoneNumber:` silently returns zero results unless `CNContactPhoneNumbersKey` is in `keysToFetch` — the unification step appears to skip contacts whose matching field wasn't requested. Fix: include the matched field's storage key in `keysToFetch` for phone (and email, for symmetry). Documented in the `contacts-framework` skill and guarded by a parametrized unit test.

## Test plan

- [x] `make test` — 193 unit tests pass (added 3 connector tests for the keysToFetch invariant + per-mode predicate calls; expanded server tests to 30 cases covering XOR validation, auth flow ×4 modes, happy path ×4 modes, response shape, value stripping).
- [x] `make coverage` — 95.91% (gate is 90%).
- [x] `make lint` / `make typecheck` / `make check-all` — clean.
- [x] `make test-integration` — all 23 integration tests pass against a real address book, including the three new phone/email/organization tests in `tests/integration/test_read_path.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)