### PR TITLE
feat: list_groups + get_contacts_in_group (closes #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `read_note(identifier)` and `write_note(identifier, note, group_identifier=None)` — first AppleScript-fallback tools. The `note` field is entitlement-gated in `Contacts.framework` so we route through `osascript` against Contacts.app. `write_note(id, note="")` clears the note; the connector also issues `save` so writes persist to disk (#19).
 - `escape_applescript_string()` helper in `utils.py` — backslash-then-quote escape for safe interpolation inside AppleScript double-quoted literals. Used by `write_note` and any future AppleScript callers (#21).
 - `write_note` added to `DESTRUCTIVE_OPERATIONS` (test-mode gated like `update_contact`).
+- `list_groups()` — enumerate all contact groups across all containers; returns `{id, name, container_id}` per entry, capped at 200 (#17).
+- `get_contacts_in_group(identifier)` — list contacts whose membership includes the given group; same 4-field shape as `list_contacts`, capped at 200; pre-flights via `_run_cn_fetch_group` so unknown identifiers return `not_found` distinctly from real-but-empty groups (#17).
 
 ### Changed
 

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -3,7 +3,7 @@
 Reference for every MCP tool the apple-contacts-mcp server exposes.
 
 **Version:** v0.1.0 (tracks the package version)
-**Tools:** 9
+**Tools:** 11
 
 The source-of-truth for tool behavior is the docstrings in
 [src/apple_contacts_mcp/server.py](../../src/apple_contacts_mcp/server.py)
@@ -475,6 +475,75 @@ def write_note(
 - **Destructive: replaces the note in full** (no append/diff semantics). Use `read_note` first if you need to preserve existing content.
 - Same AppleScript-routing caveats as `read_note`. The connector also issues a `save` after the write — without it, edits sit only in Contacts.app's in-memory state.
 - Test-mode gate is the same shape as `update_contact` (`check_test_mode_safety`, *not* `require_test_mode_for`): outside test mode the call runs freely; in test mode the contact must belong to `CONTACTS_TEST_GROUP`.
+
+---
+
+### list_groups
+
+Enumerate all contact groups across all containers.
+
+```python
+def list_groups() -> dict[str, Any]
+```
+
+**Parameters:** none.
+
+**Returns:**
+
+```jsonc
+{
+  "success": true,
+  "groups": [
+    {"id": "ABCD-…:ABGroup", "name": "Family", "container_id": "iCloud-…"}
+  ],
+  "count": 7,
+  "limit": 200
+}
+```
+
+**Error types:** `authorization_denied`, `unknown`.
+
+**Notes:**
+- Hard cap at **200 groups**. `count == limit` indicates the cap was hit; almost no real address book gets close.
+- Order is not guaranteed (matches Apple's native `groupsMatchingPredicate:` enumeration).
+- `container_id` resolves the parent `CNContainer` per group (one extra Contacts.framework call per group). Empty string is returned defensively when Apple's container lookup yields no result for a live group — shouldn't happen in practice.
+
+---
+
+### get_contacts_in_group
+
+List contacts whose membership includes the given group.
+
+```python
+def get_contacts_in_group(identifier: str) -> dict[str, Any]
+```
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `identifier` | str | — | The group's CN identifier (the `id` field returned by `list_groups`). |
+
+**Returns:**
+
+```jsonc
+{
+  "success": true,
+  "group_identifier": "ABCD-…:ABGroup",
+  "contacts": [
+    {"id": "WXYZ-…:ABPerson", "given_name": "Alice", "family_name": "Anderson", "organization": "Acme"}
+  ],
+  "count": 12,
+  "limit": 200
+}
+```
+
+**Error types:** `validation_error`, `authorization_denied`, `not_found`, `unknown`.
+
+**Notes:**
+- Returns the same 4-field shape as `list_contacts` / `search_contacts`. Use `get_contact(id)` to fetch full details for a result.
+- Hard cap at **200 contacts**. `count == limit` indicates the cap was hit.
+- **Pre-flights existence** via `_run_cn_fetch_group`: an unknown `identifier` returns `not_found` distinctly from a real-but-empty group. Costs one extra Contacts.framework call (~ms).
 
 ---
 

--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -278,6 +278,98 @@ class ContactsConnector:
             return None
         return results[0]
 
+    def _run_cn_list_groups(self) -> list[dict[str, str]]:
+        """Enumerate all groups across all containers.
+
+        Returns ``[{"id": str, "name": str, "container_id": str}, ...]``.
+        Order is not guaranteed (matches Apple's native enumeration).
+        Empty store → empty list.
+
+        Note: this is N+1 — one ``containersMatchingPredicate:`` call per
+        group to resolve ``container_id``, since ``CNGroup`` has no public
+        container accessor. Acceptable because typical users have <20
+        groups; revisit if this becomes a bottleneck.
+        """
+        from Contacts import CNContainer
+
+        store = self._get_store()
+        groups, err = store.groupsMatchingPredicate_error_(None, None)
+        if groups is None:
+            raise ContactsError(f"CN groups fetch failed: {err}")
+
+        out: list[dict[str, str]] = []
+        for g in groups:
+            cpred = CNContainer.predicateForContainerOfGroupWithIdentifier_(
+                g.identifier()
+            )
+            containers, cerr = store.containersMatchingPredicate_error_(
+                cpred, None
+            )
+            if containers is None:
+                raise ContactsError(f"CN container fetch failed: {cerr}")
+            # Defensive: Apple shouldn't return a group without a container,
+            # but the API contract doesn't forbid it — fall back to "".
+            container_id = (
+                str(containers[0].identifier())
+                if len(containers) > 0
+                else ""
+            )
+            out.append(
+                {
+                    "id": str(g.identifier()),
+                    "name": str(g.name()),
+                    "container_id": container_id,
+                }
+            )
+        return out
+
+    def _run_cn_contacts_in_group(
+        self, group_id: str, limit: int
+    ) -> list[dict[str, str]]:
+        """Return up to ``limit`` contacts whose membership includes
+        ``group_id``, as 4-field basic dicts.
+
+        No pre-flight — Apple's predicate returns ``[]`` for unknown
+        ``group_id``s without error. Existence checking is the server-tool
+        layer's job (``get_contacts_in_group`` calls
+        ``_run_cn_fetch_group`` first to dispatch ``not_found``).
+        """
+        from Contacts import (
+            CNContact,
+            CNContactFamilyNameKey,
+            CNContactGivenNameKey,
+            CNContactIdentifierKey,
+            CNContactOrganizationNameKey,
+        )
+
+        keys = [
+            CNContactIdentifierKey,
+            CNContactGivenNameKey,
+            CNContactFamilyNameKey,
+            CNContactOrganizationNameKey,
+        ]
+        pred = CNContact.predicateForContactsInGroupWithIdentifier_(group_id)
+        store = self._get_store()
+        results, err = store.unifiedContactsMatchingPredicate_keysToFetch_error_(
+            pred, keys, None
+        )
+        if results is None:
+            raise ContactsError(f"CN group-members fetch failed: {err}")
+
+        out: list[dict[str, str]] = []
+        for c in results:
+            if len(out) >= limit:
+                break
+            out.append(
+                {
+                    "id": str(c.identifier()),
+                    "given_name": str(c.givenName()),
+                    "family_name": str(c.familyName()),
+                    "organization": str(c.organizationName()),
+                }
+            )
+        return out
+
     def _run_cn_create_contact(
         self, fields: dict[str, Any], group_identifier: str | None
     ) -> str:

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -23,6 +23,7 @@ connector = ContactsConnector()
 
 _LIST_CONTACTS_MAX = 200
 _SEARCH_CONTACTS_MAX = 200
+_LIST_GROUPS_MAX = 200
 
 
 _AUTH_REMEDIATION: dict[str, str] = {
@@ -333,6 +334,104 @@ def search_contacts(
         "count": len(contacts),
         "search_field": field,
         "search_value": value,
+        "limit": _SEARCH_CONTACTS_MAX,
+    }
+
+
+@mcp.tool()
+def list_groups() -> dict[str, Any]:
+    """List all contact groups across all containers.
+
+    Each entry has ``id``, ``name``, and ``container_id``. Use the ``id``
+    with ``get_contacts_in_group(identifier)`` to enumerate the group's
+    members. Returns up to 200 groups (hard cap; nearly nobody has more).
+    Order is not guaranteed.
+
+    Returns:
+        On success: ``{"success": True, "groups": [...], "count": N,
+        "limit": 200}``. ``count == limit`` indicates the cap was hit.
+        On TCC denial: same shape as ``list_contacts`` (status,
+        remediation).
+        On unexpected failure: ``{"success": False, "error_type":
+        "unknown", "error": ...}``.
+    """
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    try:
+        groups = connector._run_cn_list_groups()
+    except Exception as exc:
+        logger.error("list_groups failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"list_groups failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    capped = groups[:_LIST_GROUPS_MAX]
+    return {
+        "success": True,
+        "groups": capped,
+        "count": len(capped),
+        "limit": _LIST_GROUPS_MAX,
+    }
+
+
+@mcp.tool()
+def get_contacts_in_group(identifier: str) -> dict[str, Any]:
+    """List contacts whose membership includes the given group.
+
+    Returns the same 4-field shape as ``list_contacts``. Use
+    ``get_contact(id)`` to fetch full details for a result. Hard cap of
+    200; ``count == limit`` indicates the cap was hit.
+
+    Pre-flights existence via ``_run_cn_fetch_group``: an unknown
+    ``identifier`` returns ``not_found`` distinctly from a real-but-empty
+    group.
+
+    Args:
+        identifier: The group's CN identifier.
+
+    Returns:
+        On success: ``{"success": True, "group_identifier": ...,
+        "contacts": [...], "count": N, "limit": 200}``.
+        On bad input: ``validation_error``.
+        On TCC denial: ``authorization_denied``.
+        On unknown identifier: ``not_found``.
+        On unexpected failure: ``unknown``.
+    """
+    if not identifier or not identifier.strip():
+        return _validation_error("identifier must be a non-empty string")
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    try:
+        group = connector._run_cn_fetch_group(identifier)
+        if group is None:
+            return {
+                "success": False,
+                "error": f"No group found with identifier {identifier!r}",
+                "error_type": "not_found",
+            }
+        contacts = connector._run_cn_contacts_in_group(
+            identifier, _SEARCH_CONTACTS_MAX
+        )
+    except Exception as exc:
+        logger.error("get_contacts_in_group failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"get_contacts_in_group failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    return {
+        "success": True,
+        "group_identifier": identifier,
+        "contacts": contacts,
+        "count": len(contacts),
         "limit": _SEARCH_CONTACTS_MAX,
     }
 

--- a/tests/integration/test_groups.py
+++ b/tests/integration/test_groups.py
@@ -1,0 +1,86 @@
+"""Integration tests for `_run_cn_list_groups` and `_run_cn_contacts_in_group`.
+
+CN-only ops, but the smoke tests guard against macOS API drift (Apple's
+`groupsMatchingPredicate` and `predicateForContactsInGroupWithIdentifier_`
+semantics aren't fully documented).
+
+Skipped by default; opt in with ``--run-integration``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apple_contacts_mcp.contacts_connector import ContactsConnector
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        "not config.getoption('--run-integration')",
+        reason="Integration tests opt-in via --run-integration",
+    ),
+]
+
+
+def test_list_groups_includes_test_group(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """The MCP-Test fixture group must show up in the enumeration."""
+    groups = real_connector._run_cn_list_groups()
+    by_id = {g["id"]: g for g in groups}
+    assert test_group in by_id, (
+        f"MCP-Test group {test_group!r} not in {sorted(by_id.keys())}"
+    )
+
+    entry = by_id[test_group]
+    assert isinstance(entry["id"], str) and entry["id"]
+    assert isinstance(entry["name"], str) and entry["name"]
+    assert isinstance(entry["container_id"], str) and entry["container_id"], (
+        f"container_id should be non-empty: {entry!r}"
+    )
+
+
+def test_list_groups_entries_have_only_three_keys(
+    real_connector: ContactsConnector, test_group: str
+) -> None:
+    """Lock the response shape; if Apple adds a new key on a future macOS,
+    the connector should still produce only the documented three."""
+    for g in real_connector._run_cn_list_groups():
+        assert set(g.keys()) == {"id", "name", "container_id"}
+
+
+def test_contacts_in_group_finds_tmp_contact(
+    real_connector: ContactsConnector,
+    test_group: str,
+    tmp_contact: str,
+) -> None:
+    """A tmp_contact created in MCP-Test must be findable via the membership
+    predicate, with the documented 4-field shape."""
+    members = real_connector._run_cn_contacts_in_group(
+        test_group, limit=200
+    )
+    ids = {m["id"] for m in members}
+    assert tmp_contact in ids, (
+        f"tmp_contact {tmp_contact!r} not in members {sorted(ids)}"
+    )
+
+    [member] = [m for m in members if m["id"] == tmp_contact]
+    assert set(member.keys()) == {
+        "id",
+        "given_name",
+        "family_name",
+        "organization",
+    }
+
+
+def test_contacts_in_group_returns_empty_for_unknown_id(
+    real_connector: ContactsConnector,
+) -> None:
+    """Apple's predicate returns [] (not error) for unknown group_ids; the
+    connector surfaces that directly. The server-tool layer is what
+    translates this into `not_found` via a separate `_run_cn_fetch_group`
+    pre-flight."""
+    fabricated = "fabricated-group-uuid-12345:ABGroup"
+    assert (
+        real_connector._run_cn_contacts_in_group(fabricated, limit=10) == []
+    )

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -1695,3 +1695,262 @@ def test_delete_contact_save_failure_raises(
     with pytest.raises(ContactsError) as exc_info:
         connector._run_cn_delete_contact("ABCD")
     assert "delete boom" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_list_groups
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_group(group_id: str, name: str) -> MagicMock:
+    g = MagicMock(name=f"CNGroup({group_id})")
+    g.identifier.return_value = group_id
+    g.name.return_value = name
+    return g
+
+
+def _make_fake_container(container_id: str) -> MagicMock:
+    c = MagicMock(name=f"CNContainer({container_id})")
+    c.identifier.return_value = container_id
+    return c
+
+
+def _install_fake_contacts_for_groups(
+    monkeypatch: pytest.MonkeyPatch,
+    groups: list[MagicMock] | None,
+    container_lookup: dict[str, list[MagicMock] | None] | None = None,
+    groups_err: object | None = None,
+) -> tuple[MagicMock, MagicMock]:
+    """Install a fake `Contacts` module exposing CNContainer + CNContact +
+    a CNContactStore whose ``groupsMatchingPredicate_error_(None, None)``
+    returns ``(groups, groups_err)`` and whose
+    ``containersMatchingPredicate_error_`` looks up by group id via
+    ``container_lookup``.
+
+    ``container_lookup`` maps group_id → (containers_list, err); a missing
+    key behaves as `(None, fake_error)` to surface raise paths cleanly.
+    """
+    fake_module = types.ModuleType("Contacts")
+
+    cn_container_class = MagicMock(name="CNContainer")
+    # Each call captures the group_id passed in; the predicate object is
+    # opaque but uniquely tied to the group via `.return_value` per call.
+    pred_factory = MagicMock(
+        name="predicateForContainerOfGroupWithIdentifier_"
+    )
+
+    def _pred_factory(group_id: str) -> MagicMock:
+        m = MagicMock(name=f"ContainerPred({group_id})")
+        m._group_id = group_id  # for the store-side dispatcher to read
+        return m
+
+    pred_factory.side_effect = _pred_factory
+    cn_container_class.predicateForContainerOfGroupWithIdentifier_ = (
+        pred_factory
+    )
+    fake_module.CNContainer = cn_container_class  # type: ignore[attr-defined]
+
+    store_instance = MagicMock(name="store_instance")
+    store_instance.groupsMatchingPredicate_error_.return_value = (
+        groups,
+        groups_err,
+    )
+
+    def _containers_dispatch(pred: MagicMock, _err: Any) -> tuple[Any, Any]:
+        gid = getattr(pred, "_group_id", None)
+        if container_lookup is not None and gid in container_lookup:
+            containers, cerr = (
+                container_lookup[gid]
+                if isinstance(container_lookup[gid], tuple)
+                else (container_lookup[gid], None)
+            )
+            return containers, cerr
+        # default: every group resolves to a single fake container
+        return [_make_fake_container(f"container-of-{gid}")], None
+
+    store_instance.containersMatchingPredicate_error_.side_effect = (
+        _containers_dispatch
+    )
+
+    cn_store_class = MagicMock(name="CNContactStore")
+    cn_store_class.alloc.return_value.init.return_value = store_instance
+    fake_module.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "Contacts", fake_module)
+    return cn_container_class, store_instance
+
+
+def test_list_groups_empty_store_returns_empty_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_contacts_for_groups(monkeypatch, groups=[])
+    connector = ContactsConnector()
+    assert connector._run_cn_list_groups() == []
+
+
+def test_list_groups_serializes_id_name_and_container_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_groups = [
+        _make_fake_group("G1", "Family"),
+        _make_fake_group("G2", "Work"),
+    ]
+    _install_fake_contacts_for_groups(monkeypatch, groups=fake_groups)
+    connector = ContactsConnector()
+    result = connector._run_cn_list_groups()
+    assert result == [
+        {"id": "G1", "name": "Family", "container_id": "container-of-G1"},
+        {"id": "G2", "name": "Work", "container_id": "container-of-G2"},
+    ]
+
+
+def test_list_groups_falls_back_to_empty_container_id_when_lookup_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_groups = [_make_fake_group("G1", "Orphan")]
+    _install_fake_contacts_for_groups(
+        monkeypatch,
+        groups=fake_groups,
+        container_lookup={"G1": ([], None)},
+    )
+    connector = ContactsConnector()
+    [entry] = connector._run_cn_list_groups()
+    assert entry["container_id"] == ""
+
+
+def test_list_groups_raises_when_groups_predicate_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_err = MagicMock(name="NSError")
+    fake_err.__str__.return_value = "groups-boom"
+    _install_fake_contacts_for_groups(
+        monkeypatch, groups=None, groups_err=fake_err
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_list_groups()
+    assert "groups-boom" in str(exc_info.value)
+
+
+def test_list_groups_raises_when_container_lookup_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_groups = [_make_fake_group("G1", "Family")]
+    fake_err = MagicMock(name="NSError")
+    fake_err.__str__.return_value = "container-boom"
+    _install_fake_contacts_for_groups(
+        monkeypatch,
+        groups=fake_groups,
+        container_lookup={"G1": (None, fake_err)},
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_list_groups()
+    assert "container-boom" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_contacts_in_group
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_contacts_for_group_members(
+    monkeypatch: pytest.MonkeyPatch,
+    results: list[MagicMock] | None,
+    fake_error: object | None = None,
+) -> tuple[MagicMock, MagicMock]:
+    """Install a fake `Contacts` module + a store whose
+    ``unifiedContactsMatchingPredicate_keysToFetch_error_`` returns
+    ``(results, fake_error)``. Returns ``(CNContact_class, store)`` for
+    predicate-call assertions.
+    """
+    fake_module = types.ModuleType("Contacts")
+    fake_module.CNContactIdentifierKey = "id_key"  # type: ignore[attr-defined]
+    fake_module.CNContactGivenNameKey = "given_key"  # type: ignore[attr-defined]
+    fake_module.CNContactFamilyNameKey = "family_key"  # type: ignore[attr-defined]
+    fake_module.CNContactOrganizationNameKey = "org_key"  # type: ignore[attr-defined]
+
+    cn_contact_class = MagicMock(name="CNContact")
+    pred_stub = MagicMock(name="MembershipPredicate")
+    cn_contact_class.predicateForContactsInGroupWithIdentifier_.return_value = (
+        pred_stub
+    )
+    fake_module.CNContact = cn_contact_class  # type: ignore[attr-defined]
+
+    store_instance = MagicMock(name="store_instance")
+    store_instance.unifiedContactsMatchingPredicate_keysToFetch_error_.return_value = (
+        results,
+        fake_error,
+    )
+    cn_store_class = MagicMock(name="CNContactStore")
+    cn_store_class.alloc.return_value.init.return_value = store_instance
+    fake_module.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "Contacts", fake_module)
+    return cn_contact_class, store_instance
+
+
+def test_contacts_in_group_predicate_uses_supplied_group_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cn_contact_class, _ = _install_fake_contacts_for_group_members(
+        monkeypatch, results=[]
+    )
+    connector = ContactsConnector()
+    connector._run_cn_contacts_in_group("MY-GROUP", limit=10)
+    cn_contact_class.predicateForContactsInGroupWithIdentifier_.assert_called_once_with(
+        "MY-GROUP"
+    )
+
+
+def test_contacts_in_group_returns_4_field_dicts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = [
+        _make_basic_contact("id-0", "Alice", "Anderson", "Acme"),
+        _make_basic_contact("id-1", "Bob", "Brown", ""),
+    ]
+    _install_fake_contacts_for_group_members(monkeypatch, results=fakes)
+    connector = ContactsConnector()
+    result = connector._run_cn_contacts_in_group("G", limit=200)
+    assert result == [
+        {"id": "id-0", "given_name": "Alice", "family_name": "Anderson", "organization": "Acme"},
+        {"id": "id-1", "given_name": "Bob", "family_name": "Brown", "organization": ""},
+    ]
+
+
+def test_contacts_in_group_caps_at_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = [_make_basic_contact(f"id-{i}") for i in range(250)]
+    _install_fake_contacts_for_group_members(monkeypatch, results=fakes)
+    connector = ContactsConnector()
+    result = connector._run_cn_contacts_in_group("G", limit=200)
+    assert len(result) == 200
+    # 201st contact's selectors must never have been touched.
+    assert fakes[200].identifier.call_count == 0
+
+
+def test_contacts_in_group_empty_for_unknown_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Apple's predicate returns [] (not error) for unknown group_ids."""
+    _install_fake_contacts_for_group_members(monkeypatch, results=[])
+    connector = ContactsConnector()
+    assert (
+        connector._run_cn_contacts_in_group("nonexistent", limit=200) == []
+    )
+
+
+def test_contacts_in_group_raises_when_store_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_err = MagicMock(name="NSError")
+    fake_err.__str__.return_value = "membership-boom"
+    _install_fake_contacts_for_group_members(
+        monkeypatch, results=None, fake_error=fake_err
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_contacts_in_group("G", limit=200)
+    assert "membership-boom" in str(exc_info.value)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -18,7 +18,9 @@ from apple_contacts_mcp.server import (
     create_contact,
     delete_contact,
     get_contact,
+    get_contacts_in_group,
     list_contacts,
+    list_groups,
     read_note,
     search_contacts,
     update_contact,
@@ -1185,3 +1187,184 @@ class TestWriteNoteErrors:
         assert result["success"] is False
         assert result["error_type"] == "unknown"
         assert "boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# list_groups
+# ---------------------------------------------------------------------------
+
+
+_FAKE_GROUPS = [
+    {"id": "G1", "name": "Family", "container_id": "C1"},
+    {"id": "G2", "name": "Work", "container_id": "C1"},
+]
+
+
+class TestListGroupsAuthFlow:
+    def test_auth_denied_passthrough_skips_list(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "denied"
+            result = list_groups()
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        mock_connector._run_cn_list_groups.assert_not_called()
+
+
+class TestListGroupsHappyPath:
+    def test_returns_groups_with_count_and_limit(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_list_groups.return_value = _FAKE_GROUPS
+            result = list_groups()
+        assert result == {
+            "success": True,
+            "groups": _FAKE_GROUPS,
+            "count": 2,
+            "limit": 200,
+        }
+
+    def test_empty_store_returns_empty_list(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_list_groups.return_value = []
+            result = list_groups()
+        assert result["success"] is True
+        assert result["groups"] == []
+        assert result["count"] == 0
+
+    def test_response_keys_are_minimal(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_list_groups.return_value = _FAKE_GROUPS
+            result = list_groups()
+        assert set(result.keys()) == {"success", "groups", "count", "limit"}
+
+
+class TestListGroupsCapDetection:
+    def test_count_equals_limit_when_cap_hit(self) -> None:
+        cap_hit = [
+            {"id": f"G{i}", "name": f"Group {i}", "container_id": "C1"}
+            for i in range(250)
+        ]
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_list_groups.return_value = cap_hit
+            result = list_groups()
+        assert result["count"] == 200
+        assert result["limit"] == 200
+        assert len(result["groups"]) == 200
+
+
+class TestListGroupsErrors:
+    def test_unexpected_exception_returns_unknown(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_list_groups.side_effect = ContactsError(
+                "boom"
+            )
+            result = list_groups()
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_contacts_in_group
+# ---------------------------------------------------------------------------
+
+
+class TestGetContactsInGroupValidation:
+    @pytest.mark.parametrize("identifier", ["", "   ", "\t"])
+    def test_blank_identifier_returns_validation_error(
+        self, identifier: str
+    ) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = get_contacts_in_group(identifier)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_fetch_group.assert_not_called()
+        mock_connector._run_cn_contacts_in_group.assert_not_called()
+
+
+class TestGetContactsInGroupAuthFlow:
+    def test_auth_denied_passthrough_skips_lookup(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "denied"
+            result = get_contacts_in_group("ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        mock_connector._run_cn_fetch_group.assert_not_called()
+
+
+class TestGetContactsInGroupNotFound:
+    def test_unknown_group_returns_not_found(self) -> None:
+        """Pre-flight via _run_cn_fetch_group → None ⇒ not_found."""
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_fetch_group.return_value = None
+            result = get_contacts_in_group("BAD-GROUP")
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+        assert "BAD-GROUP" in result["error"]
+        mock_connector._run_cn_contacts_in_group.assert_not_called()
+
+
+class TestGetContactsInGroupHappyPath:
+    def test_returns_contacts_with_group_identifier_echoed(self) -> None:
+        members = [
+            {"id": "id-0", "given_name": "A", "family_name": "B", "organization": "C"},
+        ]
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_fetch_group.return_value = "GROUP-OBJ"
+            mock_connector._run_cn_contacts_in_group.return_value = members
+            result = get_contacts_in_group("MY-GROUP")
+        assert result == {
+            "success": True,
+            "group_identifier": "MY-GROUP",
+            "contacts": members,
+            "count": 1,
+            "limit": 200,
+        }
+        mock_connector._run_cn_contacts_in_group.assert_called_once_with(
+            "MY-GROUP", 200
+        )
+
+    def test_empty_group_returns_empty_list(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_fetch_group.return_value = "GROUP-OBJ"
+            mock_connector._run_cn_contacts_in_group.return_value = []
+            result = get_contacts_in_group("EMPTY")
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["contacts"] == []
+
+
+class TestGetContactsInGroupCapDetection:
+    def test_count_equals_limit_when_cap_hit(self) -> None:
+        cap_hit = [
+            {"id": f"id-{i}", "given_name": "x", "family_name": "y", "organization": ""}
+            for i in range(200)
+        ]
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_fetch_group.return_value = "GROUP-OBJ"
+            mock_connector._run_cn_contacts_in_group.return_value = cap_hit
+            result = get_contacts_in_group("BIG")
+        assert result["count"] == 200
+        assert result["limit"] == 200
+
+
+class TestGetContactsInGroupErrors:
+    def test_unexpected_exception_returns_unknown(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_fetch_group.return_value = "GROUP-OBJ"
+            mock_connector._run_cn_contacts_in_group.side_effect = (
+                ContactsError("members-boom")
+            )
+            result = get_contacts_in_group("ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "members-boom" in result["error"]


### PR DESCRIPTION
## Summary

- `list_groups()` enumerates all contact groups across all containers via `groupsMatchingPredicate_(None, None)`. Each entry has `id`, `name`, and `container_id` per the issue spec. Hard cap 200, symmetric with `list_contacts` / `search_contacts`.
- `get_contacts_in_group(identifier)` lists members of a group via `predicateForContactsInGroupWithIdentifier_`. Pre-flights via `_run_cn_fetch_group` so unknown identifiers return `not_found` distinctly from real-but-empty groups (matches `get_contact` semantics).
- Both are pure Contacts.framework — no AppleScript needed, no test-mode gating (read-only).

## Notes

- Empirically verified `CNContainer.predicateForContainerOfGroupWithIdentifier_` exists in PyObjC and `CNGroup` has no direct container accessor — so each group needs one extra CN call to resolve its `container_id`. Acceptable: typical users have <20 groups. Documented in the connector docstring.
- Sets up #18 (`add_contact_to_group` / `remove_contact_from_group`), which will reuse `_run_cn_fetch_group` for membership writes.

## Test plan

- [x] `make test` — 260 unit tests pass (25 new across utils/connector/server).
- [x] `make coverage` — 96.62% (gate is 90%).
- [x] `make lint` / `make typecheck` / `make check-all` — clean.
- [x] `make test-integration` — all 34 integration tests pass against a real address book, including the four new tests in `tests/integration/test_groups.py` (group enumeration includes MCP-Test, response-shape lock-in, member discovery for `tmp_contact`, and the empty-list-for-fabricated-id invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)