### PR TITLE
release: v0.2.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,11 +1,11 @@
 # Apple Contacts MCP Server
 
-**Version:** v0.1.0
+**Version:** v0.2.0
 
-v0.1.0 ships the seven core CRUD tools (`check_authorization`, `list_contacts`,
-`get_contact`, `search_contacts`, `create_contact`, `update_contact`,
-`delete_contact`). See [docs/reference/TOOLS.md](../docs/reference/TOOLS.md)
-for the API surface and [CHANGELOG.md](../CHANGELOG.md) for release notes.
+v0.2.0 extends the v0.1.0 core with field-scoped search, group read/write,
+note read/write (AppleScript fallback), and vCard import/export. See
+[docs/reference/TOOLS.md](../docs/reference/TOOLS.md) for the API surface
+and [CHANGELOG.md](../CHANGELOG.md) for release notes.
 
 - `MCP_PLAYBOOK.md` is the authoritative project-agnostic reference.
 - `BOOTSTRAP.md` documents the initial repo setup (mostly historical now).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-09
+
+Phase 2 release. Eight new tools spanning field-scoped search, group read/write, note read/write (AppleScript fallback), and vCard 3.0 import/export. Two breaking input-shape changes vs v0.1.0 (`search_contacts` predicates, `label` field on labeled values).
+
 ### Added
 
 - `search_contacts` — phone, email, and organization predicate modes alongside the existing name search. Phone matching uses Apple's format-tolerant `predicateForContactsMatchingPhoneNumber:` (with `CNPhoneNumber` wrapping); email uses `predicateForContactsMatchingEmailAddress:`; organization uses a custom `CONTAINS[cd]` `NSPredicate` to mirror name-mode case- and diacritic-insensitive substring behavior (#16).
@@ -28,9 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search_contacts` success response: the `query` key is replaced by flat `search_field` + `search_value` keys. `search_value` echoes the stripped value (#16).
 - `create_contact` and `update_contact` input shape: phones / emails / urls / postal_addresses now take a `label` field instead of `label_raw`. The `label` field accepts human forms (`"mobile"`, `"home fax"`), Apple tokens (`"_$!<Mobile>!$_"`), or custom strings (`"Spotify"`); the helper translates as needed. Read-side response is unchanged — `get_contact` still emits both `label_raw` (token, identity) and `label` (Apple's localized display). **Breaking change** vs v0.1.0 (#22).
 
+### Security
+
+- Identifier escaping in AppleScript paths (`read_note`, `write_note`, `remove_contact_from_group`). CN-issued identifiers are UUID-shaped and contain no AppleScript metacharacters, so this is a no-op for legitimate input — but applies `escape_applescript_string` defensively at the connector boundary so adversarial input from an MCP caller can't inject AppleScript via the `identifier` parameter. Caught in release-gate code review.
+
 ### Documentation
 
 - vCard version-export decision recorded in [`docs/research/vcard-version-decision.md`](docs/research/vcard-version-decision.md) — emit Apple's vCard 3.0 verbatim, document limitations (NOTE omitted, year-less BDAYs use Apple's `X-APPLE-OMIT-YEAR=1604` hack that corrupts to "1604" for non-Apple consumers). Empirically probed against macOS 26.3.1. Closes gap-analysis open Q3 and unblocks `export_vcard` / `import_vcard` work in #20 (#23).
+- `read_note` tool docstring corrected — it previously claimed bare-UUID input worked, but AppleScript's `id of person` requires the `:ABPerson` suffix.
 
 ## [0.1.0] - 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,21 @@
 
 A Model Context Protocol server for Apple Contacts on macOS.
 
-**Version:** v0.1.0 — first feature release. Seven CRUD tools backed by `Contacts.framework` via PyObjC. See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for the API surface and [CHANGELOG.md](CHANGELOG.md) for release notes.
+**Version:** v0.2.0 — adds field-scoped search, group read/write, note read/write (AppleScript fallback), and vCard import/export on top of the v0.1.0 CRUD core. See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for the API surface and [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 ## Tools
 
 - `check_authorization` — TCC status pre-flight.
 - `list_contacts` — paged read.
 - `get_contact` — full P1 fetch by identifier.
-- `search_contacts` — predicate by name.
+- `search_contacts` — predicate by name, phone, email, or organization.
 - `create_contact` — write via `CNSaveRequest`.
 - `update_contact` — partial-field update.
-- `delete_contact` — test-mode-only in v0.1.0; full destructive UX ships in v0.4.0.
+- `delete_contact` — test-mode-only in v0.2.0; full destructive UX ships in v0.4.0.
+- `read_note` / `write_note` — note field via AppleScript fallback (entitlement-gated in CN).
+- `list_groups` / `get_contacts_in_group` — group read.
+- `add_contact_to_group` / `remove_contact_from_group` — group membership.
+- `export_vcard` / `import_vcard` — vCard 3.0 serialization round-trip.
 
 ## Install
 

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -2,7 +2,7 @@
 
 Reference for every MCP tool the apple-contacts-mcp server exposes.
 
-**Version:** v0.1.0 (tracks the package version)
+**Version:** v0.2.0 (tracks the package version)
 **Tools:** 15
 
 The source-of-truth for tool behavior is the docstrings in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-contacts-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server for Apple Contacts integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_contacts_mcp/__init__.py
+++ b/src/apple_contacts_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Contacts MCP Server.
 A Model Context Protocol server for Apple Contacts integration.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -111,10 +111,17 @@ class ContactsConnector:
         Bare-UUID input raises ``ContactsNotFoundError`` because AppleScript's
         ``id of person`` includes the ``:ABPerson`` suffix and ``whose id is
         "<bare-uuid>"`` won't match. Verified empirically; do not strip.
+
+        The identifier is escaped via ``escape_applescript_string`` before
+        interpolation. CN-issued identifiers contain only hex digits, hyphens,
+        colons, and letters — none of which the helper transforms — so this
+        is a no-op in normal use and a defense-in-depth boundary for
+        adversarial input.
         """
+        escaped_id = escape_applescript_string(identifier)
         script = (
             'tell application "Contacts"\n'
-            f'  set p to first person whose id is "{identifier}"\n'
+            f'  set p to first person whose id is "{escaped_id}"\n'
             "  if note of p is missing value then\n"
             '    return ""\n'
             "  else\n"
@@ -142,11 +149,12 @@ class ContactsConnector:
         doesn't exist. ``identifier`` must be the full ``<UUID>:ABPerson``
         CN identifier (see ``_run_applescript_read_note`` for why).
         """
-        escaped = escape_applescript_string(note)
+        escaped_note = escape_applescript_string(note)
+        escaped_id = escape_applescript_string(identifier)
         script = (
             'tell application "Contacts"\n'
-            f'  set p to first person whose id is "{identifier}"\n'
-            f'  set note of p to "{escaped}"\n'
+            f'  set p to first person whose id is "{escaped_id}"\n'
+            f'  set note of p to "{escaped_note}"\n'
             "  save\n"
             "end tell"
         )
@@ -637,19 +645,23 @@ class ContactsConnector:
         disambiguating text. AppleScript would otherwise produce a
         generic "Can't get …" error that we'd have to parse.
 
-        Identifiers are interpolated raw — both are CN-issued UUIDs +
-        suffix and don't need escaping. The ``save`` is load-bearing
-        (same reason as ``write_note``).
+        Identifiers are escaped via ``escape_applescript_string`` as
+        defense-in-depth — CN-issued identifiers contain only hex digits,
+        hyphens, colons, and letters, so the helper is a no-op for
+        legitimate input but blocks AppleScript injection on adversarial
+        input. The ``save`` is load-bearing (same reason as ``write_note``).
         """
         # Pre-flight: raises ContactsNotFoundError("Contact not found: ...")
         # or ContactsNotFoundError("Group not found: ...") as appropriate.
         # We discard the returned objects; AppleScript operates on ids.
         self._load_contact_and_group(contact_identifier, group_identifier)
 
+        escaped_contact_id = escape_applescript_string(contact_identifier)
+        escaped_group_id = escape_applescript_string(group_identifier)
         script = (
             'tell application "Contacts"\n'
-            f'  set p to first person whose id is "{contact_identifier}"\n'
-            f'  set g to first group whose id is "{group_identifier}"\n'
+            f'  set p to first person whose id is "{escaped_contact_id}"\n'
+            f'  set g to first group whose id is "{escaped_group_id}"\n'
             "  remove p from g\n"
             "  save\n"
             "end tell"

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -1009,8 +1009,10 @@ def read_note(identifier: str) -> dict[str, Any]:
     this tool routes through ``osascript`` against Contacts.app.
 
     Args:
-        identifier: The contact's CN identifier (e.g.
-            ``"BD0B...:ABPerson"`` or just the bare UUID).
+        identifier: The contact's full CN identifier including the
+            ``:ABPerson`` suffix (e.g., ``"BD0B...:ABPerson"``). Bare UUIDs
+            are not accepted — AppleScript's ``id of person`` includes the
+            suffix and won't match without it.
 
     Returns:
         On success: ``{"success": True, "identifier": ..., "note": ...}``.

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -196,6 +196,25 @@ def test_write_note_passes_identifier_through_unchanged() -> None:
     assert 'first person whose id is "ABCD-1234:ABPerson"' in script
 
 
+def test_write_note_escapes_adversarial_identifier() -> None:
+    """Defense-in-depth: identifiers containing AppleScript metacharacters
+    are escaped before interpolation. Real CN identifiers never contain
+    these characters, so this is a safety net for adversarial input."""
+    connector = ContactsConnector()
+    with _patch_run_applescript(connector, return_value="") as mock:
+        connector._run_applescript_write_note('x" & "y', "note")
+    (script,) = mock.call_args.args
+    assert 'first person whose id is "x\\" & \\"y"' in script
+
+
+def test_read_note_escapes_adversarial_identifier() -> None:
+    connector = ContactsConnector()
+    with _patch_run_applescript(connector, return_value="") as mock:
+        connector._run_applescript_read_note('x" & "y')
+    (script,) = mock.call_args.args
+    assert 'first person whose id is "x\\" & \\"y"' in script
+
+
 def test_write_note_maps_not_found_pattern_to_contacts_not_found() -> None:
     connector = ContactsConnector()
     err = ContactsAppleScriptError(
@@ -2191,6 +2210,27 @@ def test_remove_contact_from_group_reraises_unrelated_applescript_error(
                 "CONTACT-1", "GROUP-1"
             )
     assert "permission denied" in str(exc_info.value)
+
+
+def test_remove_contact_from_group_escapes_adversarial_identifiers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense-in-depth: identifiers containing AppleScript metacharacters
+    are escaped before interpolation. Real CN identifiers never contain
+    these characters, so this is a safety net for adversarial input."""
+    fetched = MagicMock(name="fetched_contact")
+    fake_group = MagicMock(name="CNGroup_instance")
+    _install_fake_contacts_for_modify(
+        monkeypatch, fetched_contact=fetched, group_results=[fake_group]
+    )
+    connector = ContactsConnector()
+    with patch.object(connector, "_run_applescript", return_value="") as mock:
+        connector._run_applescript_remove_contact_from_group(
+            'c" & "x', 'g" & "y'
+        )
+    (script,) = mock.call_args.args
+    assert 'first person whose id is "c\\" & \\"x"' in script
+    assert 'first group whose id is "g\\" & \\"y"' in script
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -12,7 +12,7 @@ from apple_contacts_mcp.security import sanitize_input
 
 
 def test_version() -> None:
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.2.0"
 
 
 def test_connector_instantiates() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "apple-contacts-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

v0.2.0 — Phase 2 release. Eight new tools on top of the v0.1.0 CRUD core: field-scoped `search_contacts` (phone/email/organization), `read_note`/`write_note` (first AppleScript-fallback tools, since Contacts.framework gates `note` on entitlement), group read (`list_groups`, `get_contacts_in_group`) and group membership writes (`add_contact_to_group`, `remove_contact_from_group`), and vCard 3.0 round-trip (`export_vcard`, `import_vcard`).

Two breaking input-shape changes vs v0.1.0:
- `search_contacts` — `query: str` replaced by mutually-exclusive `name` / `phone` / `email` / `organization` (#16).
- `phones` / `emails` / `urls` / `postal_addresses` on `create_contact` and `update_contact` — `label_raw` (token) replaced by `label`, which now accepts human forms (`"mobile"`), Apple tokens, or custom strings (#22).

### Release-gate review fixes

- **AppleScript identifier injection** (defense-in-depth) — `read_note`, `write_note`, and `remove_contact_from_group` previously interpolated `identifier` raw into AppleScript on the rationale that CN-issued identifiers are UUID-shaped and contain no metacharacters. True for legitimate input but not enforced at the boundary; an MCP caller could in principle inject AppleScript via a crafted identifier. Apply `escape_applescript_string` to identifiers in the connector — no-op for real CN identifiers, blocks the attack on adversarial input. Regression tests added.
- **`read_note` docstring** — corrected to match observed behavior (bare UUIDs do not work; the `:ABPerson` suffix is required).

### Validation

- `check_version_sync.sh` ✓ — all four files at 0.2.0.
- `check_client_server_parity.sh` ✓ — 15 tools, every connector method has a server tool.
- `make test` ✓ — 368 unit tests, coverage 96.90% (over 90% threshold).
- `check_dependencies.sh` ✓ — no known vulnerabilities.
- `check_complexity.sh` ⚠️ — exits non-zero because `radon` can't parse Python 3.10's `match` statement (introduced in #53 for `search_contacts`). Pre-existing, not introduced by this release; the same complexity violations existed in v0.1.0. **Worth fixing in a follow-up** (either upgrade `radon` or rewrite the `match` as if/elif).
- `check_applescript_safety.sh` — deferred to v0.4.0 per CLAUDE.md.

## Test plan

- [ ] Tests pass in CI
- [ ] Manual smoke: `read_note` / `write_note` against a real contact
- [ ] Manual smoke: `add_contact_to_group` + `remove_contact_from_group` with `CONTACTS_TEST_MODE=true`
- [ ] Manual smoke: `export_vcard` round-tripped via `import_vcard`
- [ ] Manual smoke: `search_contacts` with each of `name=`, `phone=`, `email=`, `organization=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)