### PR TITLE
Fix complexity check on search contacts

### DIFF
--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -718,36 +718,35 @@ class ContactsConnector:
             CNContactFamilyNameKey,
             CNContactOrganizationNameKey,
         ]
-        match field:
-            case "name":
-                pred = CNContact.predicateForContactsMatchingName_(value)
-            case "phone":
-                from Contacts import CNPhoneNumber
+        if field == "name":
+            pred = CNContact.predicateForContactsMatchingName_(value)
+        elif field == "phone":
+            from Contacts import CNPhoneNumber
 
-                # Apple's phone predicate silently returns zero results if
-                # CNContactPhoneNumbersKey isn't in keysToFetch — the
-                # unification step skips contacts whose matching field
-                # wasn't requested. Empirically verified; not documented.
-                keys.append(CNContactPhoneNumbersKey)
-                pred = CNContact.predicateForContactsMatchingPhoneNumber_(
-                    CNPhoneNumber.phoneNumberWithStringValue_(value)
-                )
-            case "email":
-                # Email predicate currently matches without
-                # CNContactEmailAddressesKey, but include it for symmetry
-                # with phone in case Apple tightens the unification step.
-                keys.append(CNContactEmailAddressesKey)
-                pred = CNContact.predicateForContactsMatchingEmailAddress_(
-                    value
-                )
-            case "organization":
-                from Foundation import NSPredicate
+            # Apple's phone predicate silently returns zero results if
+            # CNContactPhoneNumbersKey isn't in keysToFetch — the
+            # unification step skips contacts whose matching field
+            # wasn't requested. Empirically verified; not documented.
+            keys.append(CNContactPhoneNumbersKey)
+            pred = CNContact.predicateForContactsMatchingPhoneNumber_(
+                CNPhoneNumber.phoneNumberWithStringValue_(value)
+            )
+        elif field == "email":
+            # Email predicate currently matches without
+            # CNContactEmailAddressesKey, but include it for symmetry
+            # with phone in case Apple tightens the unification step.
+            keys.append(CNContactEmailAddressesKey)
+            pred = CNContact.predicateForContactsMatchingEmailAddress_(
+                value
+            )
+        elif field == "organization":
+            from Foundation import NSPredicate
 
-                pred = NSPredicate.predicateWithFormat_(
-                    "organizationName CONTAINS[cd] %@", value
-                )
-            case _:
-                raise ContactsError(f"Unknown search field: {field!r}")
+            pred = NSPredicate.predicateWithFormat_(
+                "organizationName CONTAINS[cd] %@", value
+            )
+        else:
+            raise ContactsError(f"Unknown search field: {field!r}")
 
         store = self._get_store()
         results, err = store.unifiedContactsMatchingPredicate_keysToFetch_error_(


### PR DESCRIPTION
## Summary
- replace the Python 3.10 `match` statement in `_run_cn_search_contacts` with equivalent `if`/`elif` dispatch
- keep the existing name/phone/email/organization predicate behavior and unknown-field error path unchanged
- lets `scripts/check_complexity.sh` run with the currently locked Radon parser while avoiding a broader dependency churn

Fixes #61.

## Verification
- `git diff --check`
- `python3 -m py_compile src/apple_contacts_mcp/contacts_connector.py tests/unit/test_contacts_connector.py`
- static assertion that `match field:` is removed and the organization branch remains present

I could not run the pytest suite or Radon script in this WSL profile because `pytest`/`radon` are not installed here; the change is intentionally limited to syntax-equivalent control flow covered by the existing search-contact unit tests.
