### PR TITLE
fix: check_complexity.sh runs under project Python + honest gate (closes #61)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
 
       - name: Complexity check
         run: ./scripts/check_complexity.sh
-        continue-on-error: true
 
       - name: Version sync check
         run: ./scripts/check_version_sync.sh

--- a/scripts/check_complexity.sh
+++ b/scripts/check_complexity.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 # Check cyclomatic complexity of Python source files using radon.
 # Threshold: CC <= 20 for new code. Documented exceptions allowed.
+#
+# Always invoked via `uv run` so radon executes under the project's pinned
+# Python (3.10+) — earlier interpreters can't parse `match` statements
+# introduced in #53.
 set -euo pipefail
 
 THRESHOLD=20
 SRC_DIR="src/apple_contacts_mcp"
 
-if ! command -v radon &> /dev/null; then
-    if command -v uv &> /dev/null; then
-        echo "Installing radon..."
-        uv pip install radon -q
-    else
-        echo "Error: radon not found. Install with: pip install radon"
-        exit 1
-    fi
+if ! command -v uv &> /dev/null; then
+    echo "Error: uv not found. Install from https://docs.astral.sh/uv/."
+    exit 1
 fi
 
 echo "Checking cyclomatic complexity (threshold: CC <= $THRESHOLD)..."
 echo ""
 
-# Get complexity report
-REPORT=$(radon cc "$SRC_DIR" -n C -s 2>&1) || true
+# Visibility report — show every function ranked C or worse (CC >= 11) so
+# we surface things drifting upward before they breach the gate.
+REPORT=$(uv run radon cc "$SRC_DIR" -n C -s)
 
 if [ -z "$REPORT" ]; then
     echo "All functions have complexity <= B (acceptable)."
@@ -30,25 +30,23 @@ fi
 echo "$REPORT"
 echo ""
 
-# Check for functions exceeding threshold
-FAILURES=$(radon cc "$SRC_DIR" -n F -j 2>&1 | python3 -c "
+# Gate. `-n A` emits every function — we then apply $THRESHOLD honestly in
+# Python. (The previous `-n F` filter only emitted CC>=41, which let
+# CC=21..40 functions slip through despite the documented threshold.)
+uv run radon cc "$SRC_DIR" -n A -j | uv run python -c "
 import json, sys
 data = json.load(sys.stdin)
 failures = []
 for filepath, functions in data.items():
     for func in functions:
         if func['complexity'] > $THRESHOLD:
-            failures.append(f\"  {filepath}:{func['lineno']} {func['name']} (CC={func['complexity']})\")
+            failures.append(
+                f\"  {filepath}:{func['lineno']} {func['name']} (CC={func['complexity']})\"
+            )
 if failures:
     print('Functions exceeding threshold:')
     for f in failures:
         print(f)
     sys.exit(1)
-else:
-    print('All functions within threshold.')
-" 2>&1) || {
-    echo "$FAILURES"
-    exit 1
-}
-
-echo "$FAILURES"
+print('All functions within threshold.')
+"

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -436,6 +436,82 @@ def get_contacts_in_group(identifier: str) -> dict[str, Any]:
     }
 
 
+def _validate_phones(
+    phones: list[dict[str, str]] | None,
+) -> dict[str, Any] | None:
+    for i, p in enumerate(phones or []):
+        if not (p.get("value") or "").strip():
+            return _validation_error(f"phones[{i}].value must be non-empty")
+    return None
+
+
+def _validate_emails(
+    emails: list[dict[str, str]] | None,
+) -> dict[str, Any] | None:
+    for i, e in enumerate(emails or []):
+        v = (e.get("value") or "").strip()
+        if not v:
+            return _validation_error(f"emails[{i}].value must be non-empty")
+        if "@" not in v:
+            return _validation_error(f"emails[{i}].value must contain '@'")
+    return None
+
+
+def _validate_urls(
+    urls: list[dict[str, str]] | None,
+) -> dict[str, Any] | None:
+    for i, u in enumerate(urls or []):
+        if not (u.get("value") or "").strip():
+            return _validation_error(f"urls[{i}].value must be non-empty")
+    return None
+
+
+def _validate_postal_addresses(
+    addrs: list[dict[str, str]] | None,
+) -> dict[str, Any] | None:
+    for i, a in enumerate(addrs or []):
+        if not any(
+            (a.get(k) or "").strip()
+            for k in ("street", "city", "state", "postal_code", "country")
+        ):
+            return _validation_error(
+                f"postal_addresses[{i}] must set at least one of "
+                f"street/city/state/postal_code/country"
+            )
+    return None
+
+
+def _validate_birthday(
+    bday: dict[str, int] | None,
+) -> dict[str, Any] | None:
+    if bday is None:
+        return None
+    m = bday.get("month")
+    d = bday.get("day")
+    y = bday.get("year")
+    if m is not None and not (1 <= m <= 12):
+        return _validation_error("birthday.month must be 1-12")
+    if d is not None and not (1 <= d <= 31):
+        return _validation_error("birthday.day must be 1-31")
+    if y is not None and y <= 0:
+        return _validation_error("birthday.year must be > 0 if set")
+    return None
+
+
+def _validate_labeled_value_fields(
+    fields: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Run the per-field-type validators shared by create_contact and
+    update_contact. First failure short-circuits."""
+    return (
+        _validate_phones(fields.get("phones"))
+        or _validate_emails(fields.get("emails"))
+        or _validate_urls(fields.get("urls"))
+        or _validate_postal_addresses(fields.get("postal_addresses"))
+        or _validate_birthday(fields.get("birthday"))
+    )
+
+
 def _validate_create_contact_input(
     fields: dict[str, Any],
 ) -> dict[str, Any] | None:
@@ -450,45 +526,7 @@ def _validate_create_contact_input(
             "At least one of given_name, family_name, or organization "
             "must be set."
         )
-
-    for i, p in enumerate(fields.get("phones") or []):
-        if not (p.get("value") or "").strip():
-            return _validation_error(f"phones[{i}].value must be non-empty")
-
-    for i, e in enumerate(fields.get("emails") or []):
-        v = (e.get("value") or "").strip()
-        if not v:
-            return _validation_error(f"emails[{i}].value must be non-empty")
-        if "@" not in v:
-            return _validation_error(f"emails[{i}].value must contain '@'")
-
-    for i, u in enumerate(fields.get("urls") or []):
-        if not (u.get("value") or "").strip():
-            return _validation_error(f"urls[{i}].value must be non-empty")
-
-    for i, a in enumerate(fields.get("postal_addresses") or []):
-        if not any(
-            (a.get(k) or "").strip()
-            for k in ("street", "city", "state", "postal_code", "country")
-        ):
-            return _validation_error(
-                f"postal_addresses[{i}] must set at least one of "
-                f"street/city/state/postal_code/country"
-            )
-
-    bday = fields.get("birthday")
-    if bday is not None:
-        m = bday.get("month")
-        d = bday.get("day")
-        y = bday.get("year")
-        if m is not None and not (1 <= m <= 12):
-            return _validation_error("birthday.month must be 1-12")
-        if d is not None and not (1 <= d <= 31):
-            return _validation_error("birthday.day must be 1-31")
-        if y is not None and y <= 0:
-            return _validation_error("birthday.year must be > 0 if set")
-
-    return None
+    return _validate_labeled_value_fields(fields)
 
 
 def _validation_error(msg: str) -> dict[str, Any]:
@@ -622,50 +660,11 @@ def _validate_update_contact_input(
     dict otherwise."""
     if not identifier or not identifier.strip():
         return _validation_error("identifier must be a non-empty string")
-
     if len(fields) == 0:
         return _validation_error(
             "At least one field must be supplied to update."
         )
-
-    for i, p in enumerate(fields.get("phones") or []):
-        if not (p.get("value") or "").strip():
-            return _validation_error(f"phones[{i}].value must be non-empty")
-
-    for i, e in enumerate(fields.get("emails") or []):
-        v = (e.get("value") or "").strip()
-        if not v:
-            return _validation_error(f"emails[{i}].value must be non-empty")
-        if "@" not in v:
-            return _validation_error(f"emails[{i}].value must contain '@'")
-
-    for i, u in enumerate(fields.get("urls") or []):
-        if not (u.get("value") or "").strip():
-            return _validation_error(f"urls[{i}].value must be non-empty")
-
-    for i, a in enumerate(fields.get("postal_addresses") or []):
-        if not any(
-            (a.get(k) or "").strip()
-            for k in ("street", "city", "state", "postal_code", "country")
-        ):
-            return _validation_error(
-                f"postal_addresses[{i}] must set at least one of "
-                f"street/city/state/postal_code/country"
-            )
-
-    bday = fields.get("birthday")
-    if bday is not None:
-        m = bday.get("month")
-        d = bday.get("day")
-        y = bday.get("year")
-        if m is not None and not (1 <= m <= 12):
-            return _validation_error("birthday.month must be 1-12")
-        if d is not None and not (1 <= d <= 31):
-            return _validation_error("birthday.day must be 1-31")
-        if y is not None and y <= 0:
-            return _validation_error("birthday.year must be > 0 if set")
-
-    return None
+    return _validate_labeled_value_fields(fields)
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

Three fixes that together resolve #61:

1. **Root cause: script invokes the wrong Python.** `scripts/check_complexity.sh` did `command -v radon`, which on developer machines often resolves to a system Python 3.9 install that can't parse `match`. Switch to `uv run radon` so radon always runs under the project's pinned Python (3.10+). The `match` statement in `_run_cn_search_contacts` stays — it's the more readable form.

2. **Gate logic didn't match documentation.** The script announced `THRESHOLD=20` but gated with `radon -n F -j` (only emits CC≥41). So functions at CC=21–40 silently passed. Switch to `-n A` (all ranks) and apply `$THRESHOLD` honestly in the Python filter.

3. **CI was swallowing failures.** `.github/workflows/test.yml` had `continue-on-error: true` on the complexity step — drop it. Once the script is honest, regressions should fail CI.

To clear the now-honest gate, refactor the two pre-existing CC>20 violators by extracting the duplicated per-field-type checks into shared helpers:

- `_validate_phones`
- `_validate_emails`
- `_validate_urls`
- `_validate_postal_addresses`
- `_validate_birthday`
- `_validate_labeled_value_fields` — thin chain that runs all of the above

Both `_validate_create_contact_input` (CC=32 → 4) and `_validate_update_contact_input` (CC=29 → 5) drop well below the threshold, and ~50 lines of duplicated body collapse into one place. Behavior preserved — the existing 368-test suite is the regression net (extensive coverage at `tests/unit/test_server.py:551–619` exercises every per-field rule end-to-end through `create_contact`).

### Note re: #63

Contributor @alceops opened #63 with a parallel fix that rewrites the `match` statement as if/elif. That's the surgical workaround listed in the #61 issue body. After review, going with this comprehensive approach instead — it addresses the actual root cause (script doesn't use project Python) plus the gate-logic and CI-silencer bugs that #63 doesn't touch, and keeps the `match` for readability. Closing #63 with a thank-you note.

## Verification

- `./scripts/check_complexity.sh` → exit 0; only `create_contact` (CC=11), `_build_mutable_contact` (CC=19), `_apply_update_fields` (CC=12) appear in the visibility report; no functions exceed threshold.
- `make test` → 368 passed.
- `make coverage` → 97.71% (up from 96.90%).
- `./scripts/check_version_sync.sh` → ✓
- `./scripts/check_client_server_parity.sh` → ✓

## Test plan

- [ ] CI runs the complexity check without `continue-on-error` and reports green.
- [ ] No regressions on `create_contact` / `update_contact` validation responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)