### PR TITLE
fix: create_contact always includes group_id, null when absent (closes #62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `create_contact` success response: `group_id` is now always present, `null` when `group_identifier` was not supplied. Aligns with `import_vcard`'s existing shape so callers can use one detection idiom (`response["group_id"] is not None`) across both tools. **Breaking shape change** vs v0.2.0; callers using `"group_id" in response` to detect group assignment must switch (#62).
+
 ## [0.2.0] - 2026-05-09
 
 Phase 2 release. Eight new tools spanning field-scoped search, group read/write, note read/write (AppleScript fallback), and vCard 3.0 import/export. Two breaking input-shape changes vs v0.1.0 (`search_contacts` predicates, `label` field on labeled values).

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -29,6 +29,11 @@ When you add a new `@mcp.tool()`, mirror this layout. Group tools
 under the version they shipped in (`## Phase 1 Tools (v0.1.0)`,
 `## Phase 2 Tools (v0.2.0)`, …).
 
+**Response-shape convention.** Optional id-echo keys (`group_id`, etc.) in
+success responses are **always present**, set to `null` when the
+corresponding input was not supplied. Callers should detect "was a group
+assigned?" via `response["group_id"] is not None`, not via key presence.
+
 ---
 
 ## Phase 1 Tools (v0.1.0)
@@ -296,7 +301,7 @@ At least one of `given_name`, `family_name`, or `organization` must be non-empty
 
 ```jsonc
 // Without group
-{"success": true, "identifier": "ABCD-…"}
+{"success": true, "identifier": "ABCD-…", "group_id": null}
 
 // With group
 {"success": true, "identifier": "ABCD-…", "group_id": "GROUP-XYZ"}

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -586,7 +586,7 @@ def create_contact(
 
     Returns:
         On success: ``{"success": True, "identifier": "...",
-        "group_id": "..."}``. ``group_id`` is omitted when
+        "group_id": ...}``. ``group_id`` is ``null`` when
         ``group_identifier`` was None.
         On bad input: ``{"success": False, "error_type":
         "validation_error", "error": ...}``.
@@ -647,10 +647,11 @@ def create_contact(
             "error_type": "unknown",
         }
 
-    response: dict[str, Any] = {"success": True, "identifier": identifier}
-    if group_identifier is not None:
-        response["group_id"] = group_identifier
-    return response
+    return {
+        "success": True,
+        "identifier": identifier,
+        "group_id": group_identifier,
+    }
 
 
 def _validate_update_contact_input(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -667,12 +667,16 @@ class TestCreateContactTestModeSafety:
 
 
 class TestCreateContactHappyPath:
-    def test_minimal_returns_identifier_no_group(self) -> None:
+    def test_minimal_returns_identifier_with_null_group_id(self) -> None:
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
             mock_connector._run_cn_authorization_status.return_value = "authorized"
             mock_connector._run_cn_create_contact.return_value = "NEW-ID-1"
             result = create_contact(given_name="Alice")
-        assert result == {"success": True, "identifier": "NEW-ID-1"}
+        assert result == {
+            "success": True,
+            "identifier": "NEW-ID-1",
+            "group_id": None,
+        }
         mock_connector._run_cn_create_contact.assert_called_once()
         kwargs = mock_connector._run_cn_create_contact.call_args.kwargs
         assert kwargs["group_identifier"] is None
@@ -690,6 +694,13 @@ class TestCreateContactHappyPath:
             "identifier": "NEW-ID-2",
             "group_id": "GROUP-XYZ",
         }
+
+    def test_response_keys_are_minimal(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_contact.return_value = "NEW"
+            result = create_contact(given_name="Alice")
+        assert set(result.keys()) == {"success", "identifier", "group_id"}
 
     def test_full_field_set_passes_through_to_connector(self) -> None:
         with patch("apple_contacts_mcp.server.connector") as mock_connector:


### PR DESCRIPTION
## Summary

`create_contact` and `import_vcard` both echo `group_identifier` back as `group_id` in their success response, but disagreed on the no-group case: `create_contact` omitted the key entirely, `import_vcard` always included it as `null`. Caller code checking `"group_id" in response` got inconsistent behavior across the two tools.

Aligns on `import_vcard`'s shape (always-include, null when absent) per the user's lean in #62 — easier for typed clients and matches the more thorough tool's existing convention. Only `create_contact` needed to change.

### Changes

- **server.py** — `create_contact` returns `{"success": True, "identifier": ..., "group_id": ...}` unconditionally; `group_id` is `None` when `group_identifier` was not supplied. Docstring updated.
- **TOOLS.md** — `create_contact` Returns example now shows the no-group case as `"group_id": null`. Added a one-line **Response-shape convention** to the top-of-file Format section: optional id-echo keys are always present, set to `null` when input was absent. Single source of truth for future tools.
- **CHANGELOG.md** — `[Unreleased] / Changed` entry documenting the breaking shape change with the migration idiom (`response["group_id"] is not None`).
- **tests/unit/test_server.py** — Updated `test_minimal_returns_identifier_no_group` to assert `group_id: None`; renamed for clarity. Added `test_response_keys_are_minimal` mirroring the existing `import_vcard` test, locks the response shape.

### Verification

- `make test` → 369 passed.
- `make coverage` → 97.70%.
- `./scripts/check_complexity.sh` → exit 0; no functions exceed threshold.
- `./scripts/check_version_sync.sh` / `check_client_server_parity.sh` → ✓.

## Test plan

- [ ] CI runs the full gate (now without `continue-on-error` on complexity, post-#64) and reports green.
- [ ] No regression on either tool's success response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)