### PR TITLE
release: v0.2.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,9 +1,11 @@
 # Apple Contacts MCP Server
 
-**Version:** v0.2.0
+**Version:** v0.2.1
 
-v0.2.0 extends the v0.1.0 core with field-scoped search, group read/write,
-note read/write (AppleScript fallback), and vCard import/export. See
+v0.2.1 is a patch release covering release-gate follow-ups from v0.2.0:
+fixes the `check_complexity.sh` script and refactors the validators it
+flagged, and aligns `create_contact`'s success response with `import_vcard`
+on `group_id` shape (always present, `null` when no group). See
 [docs/reference/TOOLS.md](../docs/reference/TOOLS.md) for the API surface
 and [CHANGELOG.md](../CHANGELOG.md) for release notes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-09
+
+Patch release covering release-gate follow-ups from v0.2.0. One breaking shape change (`create_contact` `group_id`) and one infrastructure fix (`check_complexity.sh` actually enforces the documented threshold now).
+
 ### Changed
 
 - `create_contact` success response: `group_id` is now always present, `null` when `group_identifier` was not supplied. Aligns with `import_vcard`'s existing shape so callers can use one detection idiom (`response["group_id"] is not None`) across both tools. **Breaking shape change** vs v0.2.0; callers using `"group_id" in response` to detect group assignment must switch (#62).
+- `_validate_create_contact_input` and `_validate_update_contact_input` refactored — duplicated per-field-type checks (phones / emails / urls / postal addresses / birthday) extracted into shared module-level helpers (`_validate_phones`, `_validate_emails`, `_validate_urls`, `_validate_postal_addresses`, `_validate_birthday`, `_validate_labeled_value_fields`). Behavior preserved; both outer validators drop from CC=32/29 to single digits, and ~50 lines of duplicated body collapse into one place (#61).
+
+### Fixed
+
+- `scripts/check_complexity.sh` had been silently failing on every PR since #53 introduced a Python 3.10 `match` statement. Two underlying bugs: (1) the script invoked whatever `radon` was on `PATH`, which on developer machines often resolved to a system-Python-3.9 install that can't parse `match` — switch to `uv run radon` so it always uses the project's pinned Python (3.10+); (2) the gate used `radon -n F` (CC≥41) despite documenting `THRESHOLD=20` — switch to `-n A` and apply the documented threshold honestly. Also drop `continue-on-error: true` from `.github/workflows/test.yml` so future regressions actually fail CI (#61).
+
+### Documentation
+
+- TOOLS.md gained a top-of-file **Response-shape convention** note: optional id-echo keys (`group_id`, etc.) in success responses are always present, set to `null` when input was absent. Single source of truth for all current and future tools (#62).
 
 ## [0.2.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.1] - 2026-05-09
+## [0.2.1] - 2026-05-10
 
 Patch release covering release-gate follow-ups from v0.2.0. One breaking shape change (`create_contact` `group_id`) and one infrastructure fix (`check_complexity.sh` actually enforces the documented threshold now).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol server for Apple Contacts on macOS.
 
-**Version:** v0.2.0 — adds field-scoped search, group read/write, note read/write (AppleScript fallback), and vCard import/export on top of the v0.1.0 CRUD core. See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for the API surface and [CHANGELOG.md](CHANGELOG.md) for release notes.
+**Version:** v0.2.1 — patch release covering release-gate follow-ups from v0.2.0 (complexity-script fix + `create_contact` / `import_vcard` `group_id` response shape alignment). The full v0.2.0 surface (field-scoped search, group read/write, note read/write, vCard import/export) ships unchanged. See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for the API surface and [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 ## Tools
 
@@ -12,7 +12,7 @@ A Model Context Protocol server for Apple Contacts on macOS.
 - `search_contacts` — predicate by name, phone, email, or organization.
 - `create_contact` — write via `CNSaveRequest`.
 - `update_contact` — partial-field update.
-- `delete_contact` — test-mode-only in v0.2.0; full destructive UX ships in v0.4.0.
+- `delete_contact` — test-mode-only in v0.2.x; full destructive UX ships in v0.4.0.
 - `read_note` / `write_note` — note field via AppleScript fallback (entitlement-gated in CN).
 - `list_groups` / `get_contacts_in_group` — group read.
 - `add_contact_to_group` / `remove_contact_from_group` — group membership.

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -2,7 +2,7 @@
 
 Reference for every MCP tool the apple-contacts-mcp server exposes.
 
-**Version:** v0.2.0 (tracks the package version)
+**Version:** v0.2.1 (tracks the package version)
 **Tools:** 15
 
 The source-of-truth for tool behavior is the docstrings in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-contacts-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "MCP server for Apple Contacts integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_contacts_mcp/__init__.py
+++ b/src/apple_contacts_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Contacts MCP Server.
 A Model Context Protocol server for Apple Contacts integration.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -12,7 +12,7 @@ from apple_contacts_mcp.security import sanitize_input
 
 
 def test_version() -> None:
-    assert __version__ == "0.2.0"
+    assert __version__ == "0.2.1"
 
 
 def test_connector_instantiates() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "apple-contacts-mcp"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

v0.2.1 — patch release covering release-gate follow-ups from v0.2.0. Two issues, one breaking shape change.

### Changes

- **#61 — `check_complexity.sh` is honest now.** The script had been silently failing in CI on every PR since #53 introduced a Python 3.10 `match` statement. Three underlying bugs fixed:
  - Script invoked whatever `radon` was on `PATH`, which on developer machines often resolved to a system-Python-3.9 install that can't parse `match`. Switched to `uv run radon` so it always uses the project's pinned Python.
  - Gate used `radon -n F` (CC≥41) despite documenting `THRESHOLD=20`. Switched to `-n A` and applied the threshold honestly in the Python filter.
  - `.github/workflows/test.yml` had `continue-on-error: true` swallowing the failure. Removed.
  - To unblock the now-honest gate, refactored `_validate_create_contact_input` (CC=32) and `_validate_update_contact_input` (CC=29) by extracting per-field-type helpers (`_validate_phones`, `_validate_emails`, `_validate_urls`, `_validate_postal_addresses`, `_validate_birthday`). Both outer validators now sit at single-digit CC and ~50 lines of duplicated body collapse into one place.

- **#62 — `create_contact` / `import_vcard` `group_id` shape alignment.** `create_contact`'s success response now always includes `group_id` (set to `null` when `group_identifier` was not supplied), matching `import_vcard`'s existing shape. Callers can now use one detection idiom across both tools (`response["group_id"] is not None`). **Breaking shape change vs v0.2.0** — pre-1.0, acceptable. TOOLS.md gained a top-of-file response-shape convention note so future tools inherit the rule without per-entry repetition.

### Release-gate review fix

Reviewer caught a duplicated `read_note` docstring bullet in the CHANGELOG — the fix actually shipped in v0.2.0, so the v0.2.1 entry was stale. Removed.

### Validation

- `check_version_sync.sh` ✓ — all four files at 0.2.1.
- `check_client_server_parity.sh` ✓ — 15 tools, every connector method has a server tool.
- `check_complexity.sh` ✓ — exits 0; only `_build_mutable_contact` (CC=19) and `_apply_update_fields` (CC=12) appear in the visibility report; no functions exceed threshold.
- `make test` ✓ — 369 unit tests pass; coverage 97.70%.
- `check_dependencies.sh` ✓ — no known vulnerabilities.

## Test plan

- [ ] CI runs the now-honest complexity check (no more `continue-on-error`) and reports green.
- [ ] Manual smoke: `create_contact(given_name="X")` returns `group_id: null` in the response.
- [ ] Manual smoke: `create_contact(given_name="X", group_identifier="Y")` returns `group_id: "Y"` in the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)