### PR TITLE
feat: list_containers + container_identifier on create_contact (closes #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `list_containers` — enumerate contact containers (accounts: iCloud, Gmail, Exchange, On-My-Mac). Returns `{id, name, type, is_default}` per entry, capped at 10. `type` is one of `"local"` / `"exchange"` / `"cardDAV"` (even iCloud reports as `cardDAV` — the sync protocol). `is_default` flags the container new contacts go into when `container_identifier` isn't specified (#26).
+- `create_contact` gained an optional `container_identifier` parameter — pass a container UUID from `list_containers` to write to a non-default account; default `None` keeps current iCloud-default behavior. Response now echoes both `group_id` and `container_id` (both `null` when input absent, per the v0.2.1 response-shape convention). Empirical basis: [`docs/research/multi-container-write-decision.md`](docs/research/multi-container-write-decision.md). **Non-breaking** for existing callers (#26).
+
 ## [0.2.1] - 2026-05-10
 
 Patch release covering release-gate follow-ups from v0.2.0. One breaking shape change (`create_contact` `group_id`) and one infrastructure fix (`check_complexity.sh` actually enforces the documented threshold now).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Model Context Protocol server for Apple Contacts on macOS.
 - `list_groups` / `get_contacts_in_group` — group read.
 - `add_contact_to_group` / `remove_contact_from_group` — group membership.
 - `export_vcard` / `import_vcard` — vCard 3.0 serialization round-trip.
+- `list_containers` — list accounts (iCloud, Gmail, Exchange, On-My-Mac). Pair with `create_contact(..., container_identifier=...)` to write to a non-default container.
 
 ## Install
 

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -3,7 +3,7 @@
 Reference for every MCP tool the apple-contacts-mcp server exposes.
 
 **Version:** v0.2.1 (tracks the package version)
-**Tools:** 15
+**Tools:** 16
 
 The source-of-truth for tool behavior is the docstrings in
 [src/apple_contacts_mcp/server.py](../../src/apple_contacts_mcp/server.py)
@@ -294,22 +294,30 @@ def create_contact(
 | `postal_addresses` | list[dict] \| None | None | List of dicts with `label` + 8 postal sub-fields (`street`, `sub_locality`, `city`, `sub_administrative_area`, `state`, `postal_code`, `country`, `iso_country_code`). At least one geographic field must be non-empty. |
 | `birthday` | dict \| None | None | `{"year": int, "month": int, "day": int}` (any subset). Month 1-12, day 1-31. |
 | `group_identifier` | str \| None | None | If set, adds the new contact to this group atomically. **Required when `CONTACTS_TEST_MODE=true`** (must equal `CONTACTS_TEST_GROUP`). |
+| `container_identifier` | str \| None | None | If set, writes to this container instead of the user's default (typically iCloud). Use `list_containers` to find UUIDs. CN raises if the identifier is unknown — surfaces as `unknown`. |
 
 At least one of `given_name`, `family_name`, or `organization` must be non-empty (after `.strip()`).
 
 **Returns:**
 
 ```jsonc
-// Without group
-{"success": true, "identifier": "ABCD-…", "group_id": null}
+// Without group, default container
+{"success": true, "identifier": "ABCD-…", "group_id": null, "container_id": null}
 
-// With group
-{"success": true, "identifier": "ABCD-…", "group_id": "GROUP-XYZ"}
+// With group + non-default container
+{
+  "success": true,
+  "identifier": "ABCD-…",
+  "group_id": "GROUP-XYZ",
+  "container_id": "WXYZ-…:ABAccount"
+}
 ```
+
+Both id-echo keys follow the [response-shape convention](#format) — always present, `null` when input was absent.
 
 **Error types:** `validation_error`, `authorization_denied`, `safety_violation`, `not_found`, `unknown`.
 
-`not_found` here means `group_identifier` was supplied but didn't match any group.
+`not_found` here means `group_identifier` was supplied but didn't match any group. Unknown `container_identifier` surfaces as `unknown` (CN's save error propagates).
 
 **Notes:**
 - New contact lands in the `defaultContainerIdentifier` (typically iCloud).
@@ -709,6 +717,50 @@ def import_vcard(
 - **Atomic.** Parse failure, empty input, group-not-found, or save failure aborts the whole call. A multi-contact vCard is committed as one unit.
 - **Malformed input dispatches `validation_error`** (not `unknown`) — Apple's parser is the authority on validity, but the caller is responsible for handing us well-formed text. The `error` string preserves Apple's parser message for debuggability.
 - vCard 4.0 input is accepted (Apple parses both); after import, our internal representation is the unified Apple model regardless of input version.
+
+---
+
+## Phase 3 Tools (v0.3.0)
+
+### list_containers
+
+List all contact containers (accounts).
+
+```python
+def list_containers() -> dict[str, Any]
+```
+
+**Parameters:** none.
+
+**Returns:**
+
+```jsonc
+{
+  "success": true,
+  "containers": [
+    {"id": "F7F61738-…:ABAccount", "name": "iCloud",
+     "type": "cardDAV", "is_default": true},
+    {"id": "797C8A05-…:ABAccount", "name": "Gmail",
+     "type": "cardDAV", "is_default": false}
+  ],
+  "count": 2,
+  "limit": 10
+}
+```
+
+| Field | Description |
+|---|---|
+| `id` | CN identifier (`<UUID>:ABAccount`). Pass to `create_contact(..., container_identifier=...)`. |
+| `name` | User-visible account name. |
+| `type` | One of `"local"` / `"exchange"` / `"cardDAV"`. Even iCloud reports as `cardDAV` (the sync protocol). `"local"` is the legacy "On My Mac" account. |
+| `is_default` | `true` for the container new contacts go into when `container_identifier` is not specified. Exactly one container has this flag. |
+
+**Error types:** `authorization_denied`, `unknown`.
+
+**Notes:**
+- Hard cap at 10 (containers per user are typically <5). `count == limit` indicates the cap was hit.
+- Read-only; no test-mode gating.
+- Empirical basis for the multi-container write path: [`docs/research/multi-container-write-decision.md`](../research/multi-container-write-decision.md).
 
 ---
 

--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -56,6 +56,15 @@ _CN_AUTHORIZATION_STATUS: dict[int, str] = {
     4: "limited",  # macOS 14+
 }
 
+# CNContainerType raw values (per the Apple SDK). Verified empirically against
+# macOS 26.3.1: even iCloud comes back as cardDAV (3), since iCloud's contact
+# sync is CardDAV under the hood. Local (1) is the legacy "On My Mac" account.
+_CN_CONTAINER_TYPE: dict[int, str] = {
+    1: "local",
+    2: "exchange",
+    3: "cardDAV",
+}
+
 
 class ContactsConnector:
     """Backend connector for Apple Contacts operations."""
@@ -286,6 +295,40 @@ class ContactsConnector:
             return None
         return results[0]
 
+    def _run_cn_list_containers(self) -> list[dict[str, Any]]:
+        """Enumerate all CN containers (multi-account: iCloud, Gmail, etc.).
+
+        Returns ``[{"id": str, "name": str, "type": str, "is_default":
+        bool}, ...]``. ``type`` is one of ``"local"`` / ``"exchange"`` /
+        ``"cardDAV"`` (mapped from the CN integer enum). ``is_default``
+        flags the container that ``defaultContainerIdentifier`` points
+        at — typically iCloud on macOS.
+
+        Container enumeration is a single CN call (no N+1 like
+        ``_run_cn_list_groups``). Empty store → empty list.
+        """
+        store = self._get_store()
+        containers, err = store.containersMatchingPredicate_error_(None, None)
+        if containers is None:
+            raise ContactsError(f"CN containers fetch failed: {err}")
+
+        default_id = str(store.defaultContainerIdentifier())
+        out: list[dict[str, Any]] = []
+        for c in containers:
+            cid = str(c.identifier())
+            raw_type = int(c.type())
+            out.append(
+                {
+                    "id": cid,
+                    "name": str(c.name()),
+                    "type": _CN_CONTAINER_TYPE.get(
+                        raw_type, f"unknown({raw_type})"
+                    ),
+                    "is_default": cid == default_id,
+                }
+            )
+        return out
+
     def _run_cn_list_groups(self) -> list[dict[str, str]]:
         """Enumerate all groups across all containers.
 
@@ -379,10 +422,22 @@ class ContactsConnector:
         return out
 
     def _run_cn_create_contact(
-        self, fields: dict[str, Any], group_identifier: str | None
+        self,
+        fields: dict[str, Any],
+        group_identifier: str | None,
+        container_identifier: str | None = None,
     ) -> str:
-        """Create a contact in the default container, optionally also
+        """Create a contact in the specified container, optionally also
         adding it to a group, in a single atomic CNSaveRequest.
+
+        ``container_identifier=None`` writes to the default container
+        (typically iCloud); pass an explicit container UUID to target a
+        specific account. No pre-flight existence check — if the
+        identifier doesn't match any container, CN's
+        ``executeSaveRequest:error:`` raises and we surface it as
+        ``ContactsError`` (the server layer dispatches ``unknown``).
+        Behavior verified empirically; see
+        ``docs/research/multi-container-write-decision.md``.
 
         Returns the new contact's CN identifier (CN populates the
         CNMutableContact's identifier in-place after save).
@@ -400,7 +455,9 @@ class ContactsConnector:
                 )
 
         save_req = CNSaveRequest.alloc().init()
-        save_req.addContact_toContainerWithIdentifier_(mutable, None)
+        save_req.addContact_toContainerWithIdentifier_(
+            mutable, container_identifier
+        )
         if group is not None:
             save_req.addMember_toGroup_(mutable, group)
 

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -24,6 +24,7 @@ connector = ContactsConnector()
 _LIST_CONTACTS_MAX = 200
 _SEARCH_CONTACTS_MAX = 200
 _LIST_GROUPS_MAX = 200
+_LIST_CONTAINERS_MAX = 10
 
 
 _AUTH_REMEDIATION: dict[str, str] = {
@@ -339,6 +340,52 @@ def search_contacts(
 
 
 @mcp.tool()
+def list_containers() -> dict[str, Any]:
+    """List all contact containers (accounts).
+
+    A "container" in `Contacts.framework` is an account: iCloud, a Google
+    CardDAV account, Exchange, the legacy "On My Mac" local store, etc.
+    Each entry has ``id`` (the CN identifier), ``name`` (user-visible),
+    ``type`` (one of ``"local"``, ``"exchange"``, ``"cardDAV"``), and
+    ``is_default`` (True for the container new contacts go into when no
+    ``container_identifier`` is specified). Use the ``id`` with
+    ``create_contact(..., container_identifier=...)`` to target a
+    specific account.
+
+    Hard cap at 10 (containers per user are typically <5).
+
+    Returns:
+        On success: ``{"success": True, "containers": [...], "count": N,
+        "limit": 10}``. ``count == limit`` indicates the cap was hit.
+        On TCC denial: same shape as ``list_contacts`` (status,
+        remediation).
+        On unexpected failure: ``{"success": False, "error_type":
+        "unknown", "error": ...}``.
+    """
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    try:
+        containers = connector._run_cn_list_containers()
+    except Exception as exc:
+        logger.error("list_containers failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"list_containers failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    capped = containers[:_LIST_CONTAINERS_MAX]
+    return {
+        "success": True,
+        "containers": capped,
+        "count": len(capped),
+        "limit": _LIST_CONTAINERS_MAX,
+    }
+
+
+@mcp.tool()
 def list_groups() -> dict[str, Any]:
     """List all contact groups across all containers.
 
@@ -554,8 +601,9 @@ def create_contact(
     postal_addresses: list[dict[str, str]] | None = None,
     birthday: dict[str, int] | None = None,
     group_identifier: str | None = None,
+    container_identifier: str | None = None,
 ) -> dict[str, Any]:
-    """Create a new contact in the user's default container.
+    """Create a new contact, optionally in a non-default container.
 
     Pass any subset of the P1 fields. At least one of ``given_name``,
     ``family_name``, or ``organization`` must be non-empty. Labeled-value
@@ -565,6 +613,11 @@ def create_contact(
     ``"home fax"``, ``"iPhone"``), Apple's raw token
     (``"_$!<Mobile>!$_"``), or any custom string (``"Spotify"``).
     See ``docs/research/label-translation-decision.md``.
+
+    Without ``container_identifier``, the new contact lands in the user's
+    default container (typically iCloud). Pass a specific container UUID
+    from ``list_containers`` to write to a non-default account (e.g.,
+    Gmail/CardDAV). See ``docs/research/multi-container-write-decision.md``.
 
     In test mode (``CONTACTS_TEST_MODE=true``), ``group_identifier`` must
     be provided and must match ``CONTACTS_TEST_GROUP``. The new contact
@@ -583,11 +636,15 @@ def create_contact(
         birthday: ``{year?, month?, day?}`` (any subset).
         group_identifier: If set, the new contact is added to this group
             in the same CNSaveRequest. Required in test mode.
+        container_identifier: If set, target this container instead of
+            the default. Use ``list_containers`` to discover UUIDs. CN
+            validates existence at save time; an unknown identifier
+            surfaces as ``unknown``.
 
     Returns:
         On success: ``{"success": True, "identifier": "...",
-        "group_id": ...}``. ``group_id`` is ``null`` when
-        ``group_identifier`` was None.
+        "group_id": ..., "container_id": ...}``. Both id-echo keys are
+        ``null`` when the corresponding input was not supplied.
         On bad input: ``{"success": False, "error_type":
         "validation_error", "error": ...}``.
         On TCC denial: same shape as ``list_contacts``.
@@ -631,7 +688,9 @@ def create_contact(
 
     try:
         identifier = connector._run_cn_create_contact(
-            fields=fields, group_identifier=group_identifier
+            fields=fields,
+            group_identifier=group_identifier,
+            container_identifier=container_identifier,
         )
     except ContactsNotFoundError as exc:
         return {
@@ -651,6 +710,7 @@ def create_contact(
         "success": True,
         "identifier": identifier,
         "group_id": group_identifier,
+        "container_id": container_identifier,
     }
 
 

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -1311,6 +1311,21 @@ def test_create_contact_minimal_returns_new_identifier(
     store.executeSaveRequest_error_.assert_called_once()
 
 
+def test_create_contact_with_explicit_container_passes_uuid_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, _, save_req = _install_fake_contacts_for_create(monkeypatch)
+    connector = ContactsConnector()
+    connector._run_cn_create_contact(
+        fields={"given_name": "Alice"},
+        group_identifier=None,
+        container_identifier="GMAIL-UUID:ABAccount",
+    )
+    save_req.addContact_toContainerWithIdentifier_.assert_called_once()
+    args, _ = save_req.addContact_toContainerWithIdentifier_.call_args
+    assert args[1] == "GMAIL-UUID:ABAccount"
+
+
 def test_create_contact_sets_all_simple_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1733,6 +1748,120 @@ def test_delete_contact_save_failure_raises(
     with pytest.raises(ContactsError) as exc_info:
         connector._run_cn_delete_contact("ABCD")
     assert "delete boom" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# _run_cn_list_containers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_cn_container(
+    container_id: str, name: str, type_int: int
+) -> MagicMock:
+    c = MagicMock(name=f"CNContainer({container_id})")
+    c.identifier.return_value = container_id
+    c.name.return_value = name
+    c.type.return_value = type_int
+    return c
+
+
+def _install_fake_contacts_for_containers(
+    monkeypatch: pytest.MonkeyPatch,
+    containers: list[MagicMock] | None,
+    default_id: str = "DEFAULT-UUID:ABAccount",
+    containers_err: object | None = None,
+) -> MagicMock:
+    """Install a fake `Contacts` module whose store returns the given
+    container list from ``containersMatchingPredicate_error_`` and the
+    given ``defaultContainerIdentifier``."""
+    store_instance = MagicMock(name="store_instance")
+    store_instance.containersMatchingPredicate_error_.return_value = (
+        containers,
+        containers_err,
+    )
+    store_instance.defaultContainerIdentifier.return_value = default_id
+    _install_fake_contacts_module(monkeypatch, store_factory=store_instance)
+    return store_instance
+
+
+def test_list_containers_empty_store_returns_empty_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_contacts_for_containers(monkeypatch, containers=[])
+    connector = ContactsConnector()
+    assert connector._run_cn_list_containers() == []
+
+
+def test_list_containers_serializes_id_name_type_and_default_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    icloud = _make_fake_cn_container("ICLOUD-UUID:ABAccount", "iCloud", 3)
+    gmail = _make_fake_cn_container("GMAIL-UUID:ABAccount", "Gmail", 3)
+    _install_fake_contacts_for_containers(
+        monkeypatch,
+        containers=[icloud, gmail],
+        default_id="ICLOUD-UUID:ABAccount",
+    )
+    connector = ContactsConnector()
+    result = connector._run_cn_list_containers()
+    assert result == [
+        {
+            "id": "ICLOUD-UUID:ABAccount",
+            "name": "iCloud",
+            "type": "cardDAV",
+            "is_default": True,
+        },
+        {
+            "id": "GMAIL-UUID:ABAccount",
+            "name": "Gmail",
+            "type": "cardDAV",
+            "is_default": False,
+        },
+    ]
+
+
+def test_list_containers_maps_each_known_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    local = _make_fake_cn_container("L:ABAccount", "On My Mac", 1)
+    exchange = _make_fake_cn_container("E:ABAccount", "Work", 2)
+    carddav = _make_fake_cn_container("C:ABAccount", "iCloud", 3)
+    _install_fake_contacts_for_containers(
+        monkeypatch,
+        containers=[local, exchange, carddav],
+        default_id="C:ABAccount",
+    )
+    connector = ContactsConnector()
+    result = connector._run_cn_list_containers()
+    types = {r["name"]: r["type"] for r in result}
+    assert types == {
+        "On My Mac": "local",
+        "Work": "exchange",
+        "iCloud": "cardDAV",
+    }
+
+
+def test_list_containers_marks_unknown_type_explicitly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    weird = _make_fake_cn_container("X:ABAccount", "Future", 99)
+    _install_fake_contacts_for_containers(monkeypatch, containers=[weird])
+    connector = ContactsConnector()
+    result = connector._run_cn_list_containers()
+    assert result[0]["type"] == "unknown(99)"
+
+
+def test_list_containers_raises_when_predicate_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_contacts_for_containers(
+        monkeypatch, containers=None, containers_err="cn boom"
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_list_containers()
+    assert "CN containers fetch failed" in str(exc_info.value)
+    assert "cn boom" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -23,6 +23,7 @@ from apple_contacts_mcp.server import (
     get_contacts_in_group,
     import_vcard,
     list_contacts,
+    list_containers,
     list_groups,
     read_note,
     remove_contact_from_group,
@@ -667,7 +668,7 @@ class TestCreateContactTestModeSafety:
 
 
 class TestCreateContactHappyPath:
-    def test_minimal_returns_identifier_with_null_group_id(self) -> None:
+    def test_minimal_returns_identifier_with_null_group_and_container(self) -> None:
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
             mock_connector._run_cn_authorization_status.return_value = "authorized"
             mock_connector._run_cn_create_contact.return_value = "NEW-ID-1"
@@ -676,10 +677,12 @@ class TestCreateContactHappyPath:
             "success": True,
             "identifier": "NEW-ID-1",
             "group_id": None,
+            "container_id": None,
         }
         mock_connector._run_cn_create_contact.assert_called_once()
         kwargs = mock_connector._run_cn_create_contact.call_args.kwargs
         assert kwargs["group_identifier"] is None
+        assert kwargs["container_identifier"] is None
         assert kwargs["fields"]["given_name"] == "Alice"
 
     def test_with_group_includes_group_id_in_response(self) -> None:
@@ -693,6 +696,40 @@ class TestCreateContactHappyPath:
             "success": True,
             "identifier": "NEW-ID-2",
             "group_id": "GROUP-XYZ",
+            "container_id": None,
+        }
+
+    def test_with_container_includes_container_id_in_response(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_contact.return_value = "NEW-ID-3"
+            result = create_contact(
+                given_name="Alice",
+                container_identifier="CONTAINER-ABC:ABAccount",
+            )
+        assert result == {
+            "success": True,
+            "identifier": "NEW-ID-3",
+            "group_id": None,
+            "container_id": "CONTAINER-ABC:ABAccount",
+        }
+        kwargs = mock_connector._run_cn_create_contact.call_args.kwargs
+        assert kwargs["container_identifier"] == "CONTAINER-ABC:ABAccount"
+
+    def test_with_group_and_container_echoes_both(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_contact.return_value = "NEW-ID-4"
+            result = create_contact(
+                given_name="Alice",
+                group_identifier="GROUP-XYZ",
+                container_identifier="CONTAINER-ABC:ABAccount",
+            )
+        assert result == {
+            "success": True,
+            "identifier": "NEW-ID-4",
+            "group_id": "GROUP-XYZ",
+            "container_id": "CONTAINER-ABC:ABAccount",
         }
 
     def test_response_keys_are_minimal(self) -> None:
@@ -700,7 +737,12 @@ class TestCreateContactHappyPath:
             mock_connector._run_cn_authorization_status.return_value = "authorized"
             mock_connector._run_cn_create_contact.return_value = "NEW"
             result = create_contact(given_name="Alice")
-        assert set(result.keys()) == {"success", "identifier", "group_id"}
+        assert set(result.keys()) == {
+            "success",
+            "identifier",
+            "group_id",
+            "container_id",
+        }
 
     def test_full_field_set_passes_through_to_connector(self) -> None:
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
@@ -1278,6 +1320,109 @@ class TestListGroupsErrors:
                 "boom"
             )
             result = list_groups()
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# list_containers
+# ---------------------------------------------------------------------------
+
+
+_FAKE_CONTAINERS = [
+    {
+        "id": "C-ICLOUD:ABAccount",
+        "name": "iCloud",
+        "type": "cardDAV",
+        "is_default": True,
+    },
+    {
+        "id": "C-GMAIL:ABAccount",
+        "name": "Gmail",
+        "type": "cardDAV",
+        "is_default": False,
+    },
+]
+
+
+class TestListContainersAuthFlow:
+    def test_auth_denied_passthrough_skips_list(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "denied"
+            result = list_containers()
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        mock_connector._run_cn_list_containers.assert_not_called()
+
+
+class TestListContainersHappyPath:
+    def test_returns_containers_with_count_and_limit(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_list_containers.return_value = _FAKE_CONTAINERS
+            result = list_containers()
+        assert result == {
+            "success": True,
+            "containers": _FAKE_CONTAINERS,
+            "count": 2,
+            "limit": 10,
+        }
+
+    def test_default_flag_surfaces_per_container(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_list_containers.return_value = _FAKE_CONTAINERS
+            result = list_containers()
+        defaults = [c for c in result["containers"] if c["is_default"]]
+        assert len(defaults) == 1
+        assert defaults[0]["name"] == "iCloud"
+
+    def test_empty_store_returns_empty_list(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_list_containers.return_value = []
+            result = list_containers()
+        assert result["success"] is True
+        assert result["containers"] == []
+        assert result["count"] == 0
+
+    def test_response_keys_are_minimal(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_list_containers.return_value = _FAKE_CONTAINERS
+            result = list_containers()
+        assert set(result.keys()) == {"success", "containers", "count", "limit"}
+
+
+class TestListContainersCapDetection:
+    def test_count_equals_limit_when_cap_hit(self) -> None:
+        cap_hit = [
+            {
+                "id": f"C{i}:ABAccount",
+                "name": f"Container {i}",
+                "type": "cardDAV",
+                "is_default": i == 0,
+            }
+            for i in range(15)
+        ]
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_list_containers.return_value = cap_hit
+            result = list_containers()
+        assert result["count"] == 10
+        assert result["limit"] == 10
+        assert len(result["containers"]) == 10
+
+
+class TestListContainersErrors:
+    def test_unexpected_exception_returns_unknown(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_list_containers.side_effect = ContactsError(
+                "boom"
+            )
+            result = list_containers()
         assert result["success"] is False
         assert result["error_type"] == "unknown"
         assert "boom" in result["error"]


### PR DESCRIPTION
## Summary

First v0.3.0 feature. Exposes the multi-account/container surface of `Contacts.framework` that #29 empirically validated.

### New tool: `list_containers()`

Enumerates contact accounts (iCloud, Gmail/CardDAV, Exchange, On-My-Mac) as `{id, name, type, is_default}`. Hard cap at 10 (containers per user are typically <5).

```jsonc
{
  "success": true,
  "containers": [
    {"id": "F7F61738-…:ABAccount", "name": "iCloud",  "type": "cardDAV", "is_default": true},
    {"id": "797C8A05-…:ABAccount", "name": "Gmail",  "type": "cardDAV", "is_default": false}
  ],
  "count": 2,
  "limit": 10
}
```

- `type` is one of `"local"` / `"exchange"` / `"cardDAV"`. Even iCloud reports `cardDAV` — that's the sync protocol; `"local"` is the legacy "On My Mac" account.
- `is_default` flags the container that `defaultContainerIdentifier` points at. Lets callers find the default without a separate lookup.

### Extended: `create_contact(..., container_identifier=None)`

When unset, the contact lands in the default container (current behavior — non-breaking). When set, the contact is written to the named container via the existing `addContact:toContainerWithIdentifier:` call site. No pre-flight existence check: CN raises for unknown identifiers, and the existing `unknown` error path surfaces it.

Response now echoes both `group_id` and `container_id` (`null` when input absent, per the v0.2.1 response-shape convention from #62):

```jsonc
{"success": true, "identifier": "ABCD-…", "group_id": null, "container_id": null}
```

### Design choice

Per the [api-design skill's](.claude/skills/api-design/SKILL.md) decision tree, this is **one new tool plus a new parameter on an existing tool**, not the parallel `create_contact_in_container` the issue body originally proposed. Avoids tool sprawl and matches how `group_identifier` was integrated. 15 → 16 tools.

### Validation

- 384 unit tests pass (369 baseline + 15 new); coverage **97.77%**.
- `check_complexity.sh` ✓ — exits 0; no functions exceed CC=20.
- `check_client_server_parity.sh` ✓ — `list_containers` is wired with a matching connector method.
- `check_version_sync.sh` ✓.

## Test plan

- [ ] CI green on the now-honest complexity gate (post-#64).
- [ ] Manual smoke: `list_containers()` returns ≥1 container with `is_default: true`.
- [ ] Manual smoke: `create_contact(given_name="X", container_identifier=<gmail-uuid>, group_identifier="MCP-Test")` lands in Gmail (verify via Contacts.app); response includes both `container_id` and `group_id` echoed back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)