### PR TITLE
feat: create_group + rename_group + delete_group (closes #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `list_containers` — enumerate contact containers (accounts: iCloud, Gmail, Exchange, On-My-Mac). Returns `{id, name, type, is_default}` per entry, capped at 10. `type` is one of `"local"` / `"exchange"` / `"cardDAV"` (even iCloud reports as `cardDAV` — the sync protocol). `is_default` flags the container new contacts go into when `container_identifier` isn't specified (#26).
 - `create_contact` gained an optional `container_identifier` parameter — pass a container UUID from `list_containers` to write to a non-default account; default `None` keeps current iCloud-default behavior. Response now echoes both `group_id` and `container_id` (both `null` when input absent, per the v0.2.1 response-shape convention). Empirical basis: [`docs/research/multi-container-write-decision.md`](docs/research/multi-container-write-decision.md). **Non-breaking** for existing callers (#26).
+- `create_group(name, container_identifier=None)` — create a new contact group via `CNMutableGroup` + `CNSaveRequest.addGroup:toContainerWithIdentifier:`. Lands in the default container unless `container_identifier` is supplied. Returns `{id, name, container_id}`. Test-mode gated like `create_contact` (#24).
+- `rename_group(identifier, new_name)` — rename an existing group via `CNSaveRequest.updateGroup:`. Returns the updated `{id, name, container_id}`. Test-mode gated like `update_contact` (#24).
+- `delete_group(identifier)` — delete a group via `CNSaveRequest.deleteGroup:`. **Test-mode-only in v0.3.x** (same posture as `delete_contact`); confirmation UX ships in v0.4.0 (#36). Member contacts are NOT deleted — they remain in the address book, just lose membership in the now-removed group (#24).
+- `create_group` / `rename_group` / `delete_group` added to `DESTRUCTIVE_OPERATIONS` so the test-mode safety gate covers them.
+
+### Fixed
+
+- Stale `(#24)` reference in `require_test_mode_for`'s error message and `delete_contact`'s docstring — pointed at the Group CRUD issue (this PR) instead of the actual v0.4.0 confirmation-UX issue. Now correctly reads `(#36)` (#24).
 
 ## [0.2.1] - 2026-05-10
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Model Context Protocol server for Apple Contacts on macOS.
 - `read_note` / `write_note` — note field via AppleScript fallback (entitlement-gated in CN).
 - `list_groups` / `get_contacts_in_group` — group read.
 - `add_contact_to_group` / `remove_contact_from_group` — group membership.
+- `create_group` / `rename_group` / `delete_group` — group CRUD. `delete_group` is test-mode-only in v0.3.x; full destructive UX with confirmation prompts ships in v0.4.0.
 - `export_vcard` / `import_vcard` — vCard 3.0 serialization round-trip.
 - `list_containers` — list accounts (iCloud, Gmail, Exchange, On-My-Mac). Pair with `create_contact(..., container_identifier=...)` to write to a non-default container.
 

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -3,7 +3,7 @@
 Reference for every MCP tool the apple-contacts-mcp server exposes.
 
 **Version:** v0.2.1 (tracks the package version)
-**Tools:** 16
+**Tools:** 19
 
 The source-of-truth for tool behavior is the docstrings in
 [src/apple_contacts_mcp/server.py](../../src/apple_contacts_mcp/server.py)
@@ -761,6 +761,116 @@ def list_containers() -> dict[str, Any]
 - Hard cap at 10 (containers per user are typically <5). `count == limit` indicates the cap was hit.
 - Read-only; no test-mode gating.
 - Empirical basis for the multi-container write path: [`docs/research/multi-container-write-decision.md`](../research/multi-container-write-decision.md).
+
+### create_group
+
+Create a new contact group.
+
+```python
+def create_group(
+    name: str,
+    container_identifier: str | None = None,
+    group_identifier: str | None = None,
+) -> dict[str, Any]
+```
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `name` | str | — | The new group's name. Non-empty after stripping. |
+| `container_identifier` | str \| None | None | If set, target this container instead of the default. Use `list_containers` to discover UUIDs. CN raises on unknown identifiers; surfaces as `unknown`. |
+| `group_identifier` | str \| None | None | Test-mode safety assertion. Required in test mode (must match `CONTACTS_TEST_GROUP`); ignored otherwise. |
+
+**Returns:**
+
+```jsonc
+{
+  "success": true,
+  "group": {
+    "id": "NEW-…:ABGroup",
+    "name": "MyGroup",
+    "container_id": "F7F61738-…:ABAccount"
+  }
+}
+```
+
+**Error types:** `validation_error`, `authorization_denied`, `safety_violation`, `unknown`.
+
+**Notes:**
+- **Destructive (test-mode gated).** In test mode, `group_identifier` must equal `CONTACTS_TEST_GROUP`. The assertion is "I'm operating within the test-group scope" — same posture as `create_contact`.
+- New group lands in the default container (typically iCloud) unless `container_identifier` is supplied.
+
+### rename_group
+
+Rename an existing contact group.
+
+```python
+def rename_group(
+    identifier: str,
+    new_name: str,
+    group_identifier: str | None = None,
+) -> dict[str, Any]
+```
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `identifier` | str | — | The CN identifier of the group to rename. |
+| `new_name` | str | — | The new name. Non-empty after stripping. |
+| `group_identifier` | str \| None | None | Test-mode safety assertion. Required in test mode. |
+
+**Returns:**
+
+```jsonc
+{
+  "success": true,
+  "group": {
+    "id": "GRP-…:ABGroup",
+    "name": "Updated Name",
+    "container_id": "F7F61738-…:ABAccount"
+  }
+}
+```
+
+`id` echoes the input.
+
+**Error types:** `validation_error`, `authorization_denied`, `safety_violation`, `not_found`, `unknown`.
+
+**Notes:**
+- **Destructive (test-mode gated).** Same posture as `update_contact`.
+- The asserted scope (`group_identifier`) is independent of the target (`identifier`) — a test harness may rename any group as long as it operates within test-mode scope.
+
+### delete_group
+
+Delete an existing contact group.
+
+```python
+def delete_group(
+    identifier: str,
+    group_identifier: str | None = None,
+) -> dict[str, Any]
+```
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `identifier` | str | — | The CN identifier of the group to delete. |
+| `group_identifier` | str \| None | None | Test-mode safety assertion. Required in test mode (no other use). |
+
+**Returns:**
+
+```jsonc
+{"success": true, "identifier": "GRP-…:ABGroup"}
+```
+
+**Error types:** `validation_error`, `authorization_denied`, `safety_violation`, `not_found`, `unknown`.
+
+**Notes:**
+- **v0.3.0 only allows delete in test mode** — the full destructive UX (with confirmation prompts) ships in v0.4.0 (#36). Outside test mode this returns a `safety_violation`. Same posture as `delete_contact`.
+- **Member contacts are NOT deleted** — they remain in the address book; they just lose membership in the now-removed group.
 
 ---
 

--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -295,6 +295,122 @@ class ContactsConnector:
             return None
         return results[0]
 
+    def _resolve_container_id(self, group_identifier: str) -> str:
+        """Resolve the container id that owns the given group.
+
+        Returns ``""`` defensively if CN returns no containers — Apple
+        shouldn't surface a group without a container, but the API
+        contract doesn't forbid it.
+        """
+        from Contacts import CNContainer
+
+        store = self._get_store()
+        cpred = CNContainer.predicateForContainerOfGroupWithIdentifier_(
+            group_identifier
+        )
+        containers, cerr = store.containersMatchingPredicate_error_(
+            cpred, None
+        )
+        if containers is None:
+            raise ContactsError(f"CN container fetch failed: {cerr}")
+        if len(containers) == 0:
+            return ""
+        return str(containers[0].identifier())
+
+    def _run_cn_create_group(
+        self, name: str, container_identifier: str | None
+    ) -> dict[str, str]:
+        """Create a new group via CNSaveRequest.addGroup:toContainerWithIdentifier:.
+
+        Returns ``{"id": ..., "name": ..., "container_id": ...}`` —
+        same shape as ``_run_cn_list_groups`` entries. Container id is
+        resolved post-save via the same predicate used by list_groups;
+        falls back to ``""`` defensively (parallel to list_groups).
+
+        ``container_identifier=None`` writes to the default container
+        (typically iCloud). An unknown identifier surfaces as
+        ``ContactsError`` from ``executeSaveRequest:error:``.
+        """
+        from Contacts import CNMutableGroup, CNSaveRequest
+
+        mutable = CNMutableGroup.alloc().init()
+        mutable.setName_(name)
+
+        save_req = CNSaveRequest.alloc().init()
+        save_req.addGroup_toContainerWithIdentifier_(
+            mutable, container_identifier
+        )
+
+        store = self._get_store()
+        ok, err = store.executeSaveRequest_error_(save_req, None)
+        if not ok:
+            raise ContactsError(f"CN group create failed: {err}")
+
+        new_id = str(mutable.identifier())
+        return {
+            "id": new_id,
+            "name": str(mutable.name()),
+            "container_id": self._resolve_container_id(new_id),
+        }
+
+    def _run_cn_rename_group(
+        self, identifier: str, new_name: str
+    ) -> dict[str, str]:
+        """Rename an existing group. Returns the same 3-field dict shape
+        as ``_run_cn_create_group``.
+
+        Pre-flights via ``_run_cn_fetch_group`` so missing-group errors
+        surface as ``ContactsNotFoundError`` (the server layer dispatches
+        ``not_found``).
+        """
+        from Contacts import CNSaveRequest
+
+        group = self._run_cn_fetch_group(identifier)
+        if group is None:
+            raise ContactsNotFoundError(f"Group not found: {identifier!r}")
+
+        mutable = group.mutableCopy()
+        mutable.setName_(new_name)
+
+        save_req = CNSaveRequest.alloc().init()
+        save_req.updateGroup_(mutable)
+
+        store = self._get_store()
+        ok, err = store.executeSaveRequest_error_(save_req, None)
+        if not ok:
+            raise ContactsError(f"CN group rename failed: {err}")
+
+        return {
+            "id": identifier,
+            "name": str(mutable.name()),
+            "container_id": self._resolve_container_id(identifier),
+        }
+
+    def _run_cn_delete_group(self, identifier: str) -> str:
+        """Delete a group. Returns the deleted identifier (echo).
+
+        Pre-flights via ``_run_cn_fetch_group``. Member contacts are NOT
+        deleted — they keep existing in the address book; they just lose
+        membership in the now-removed group. (CN's ``deleteGroup_``
+        scope is the group object itself, not its contents.)
+        """
+        from Contacts import CNSaveRequest
+
+        group = self._run_cn_fetch_group(identifier)
+        if group is None:
+            raise ContactsNotFoundError(f"Group not found: {identifier!r}")
+
+        mutable = group.mutableCopy()
+        save_req = CNSaveRequest.alloc().init()
+        save_req.deleteGroup_(mutable)
+
+        store = self._get_store()
+        ok, err = store.executeSaveRequest_error_(save_req, None)
+        if not ok:
+            raise ContactsError(f"CN group delete failed: {err}")
+
+        return identifier
+
     def _run_cn_list_containers(self) -> list[dict[str, Any]]:
         """Enumerate all CN containers (multi-account: iCloud, Gmail, etc.).
 

--- a/src/apple_contacts_mcp/security.py
+++ b/src/apple_contacts_mcp/security.py
@@ -39,6 +39,9 @@ DESTRUCTIVE_OPERATIONS: frozenset[str] = frozenset(
         "add_contact_to_group",
         "remove_contact_from_group",
         "import_vcard",
+        "create_group",
+        "rename_group",
+        "delete_group",
     }
 )
 """Operations gated by `check_test_mode_safety`.
@@ -169,7 +172,7 @@ def require_test_mode_for(operation: str) -> dict[str, Any] | None:
             operation,
             f"{operation} is only available with CONTACTS_TEST_MODE=true. "
             f"The full destructive UX (with confirmation prompts) ships "
-            f"in v0.4.0 (#24).",
+            f"in v0.4.0 (#36).",
         )
     return None
 

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -840,8 +840,8 @@ def delete_contact(
 ) -> dict[str, Any]:
     """Delete an existing contact by identifier.
 
-    **v0.1.0 only allows delete in test mode** — the full destructive
-    UX (with confirmation prompts) ships in v0.4.0 (#24). Outside test
+    **v0.1.0+ only allows delete in test mode** — the full destructive
+    UX (with confirmation prompts) ships in v0.4.0 (#36). Outside test
     mode this returns a safety_violation error.
 
     In test mode (``CONTACTS_TEST_MODE=true``), ``group_identifier``
@@ -1308,6 +1308,199 @@ def remove_contact_from_group(
         "contact_identifier": contact_identifier,
         "group_identifier": group_identifier,
     }
+
+
+@mcp.tool()
+def create_group(
+    name: str,
+    container_identifier: str | None = None,
+    group_identifier: str | None = None,
+) -> dict[str, Any]:
+    """Create a new contact group.
+
+    Without ``container_identifier``, the group lands in the user's
+    default container (typically iCloud). Pass a specific container
+    UUID from ``list_containers`` to target a non-default account.
+
+    In test mode (``CONTACTS_TEST_MODE=true``), ``group_identifier``
+    must equal ``CONTACTS_TEST_GROUP`` — the assertion is "I'm
+    operating within the test-group scope," same posture as
+    ``create_contact``.
+
+    Args:
+        name: The new group's name. Must be non-empty after stripping.
+        container_identifier: If set, write to this container instead
+            of the default. CN raises on unknown identifiers; surfaces
+            as ``unknown``.
+        group_identifier: Test-mode safety assertion. Required in test
+            mode; ignored otherwise.
+
+    Returns:
+        On success: ``{"success": True, "group": {"id": ..., "name":
+        ..., "container_id": ...}}``.
+        On bad input: ``validation_error``.
+        On TCC denial: ``authorization_denied``.
+        On test-mode mismatch: ``safety_violation``.
+        On CN save failure (including unknown container): ``unknown``.
+    """
+    if not name or not name.strip():
+        return _validation_error("name must be a non-empty string")
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    safety_err = check_test_mode_safety(
+        "create_group", group=group_identifier
+    )
+    if safety_err is not None:
+        return safety_err
+
+    try:
+        group = connector._run_cn_create_group(
+            name=name, container_identifier=container_identifier
+        )
+    except Exception as exc:
+        logger.error("create_group failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"create_group failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    return {"success": True, "group": group}
+
+
+@mcp.tool()
+def rename_group(
+    identifier: str,
+    new_name: str,
+    group_identifier: str | None = None,
+) -> dict[str, Any]:
+    """Rename an existing contact group.
+
+    In test mode (``CONTACTS_TEST_MODE=true``), ``group_identifier``
+    must equal ``CONTACTS_TEST_GROUP``. The asserted scope is
+    independent of the target ``identifier``: a test harness may
+    rename any group as long as it's operating within test-mode scope.
+
+    Args:
+        identifier: The CN identifier of the group to rename.
+        new_name: The new name. Must be non-empty after stripping.
+        group_identifier: Test-mode safety assertion. Required in test
+            mode; ignored otherwise.
+
+    Returns:
+        On success: ``{"success": True, "group": {"id": ..., "name":
+        ..., "container_id": ...}}``. ``id`` echoes the input.
+        On bad input: ``validation_error``.
+        On TCC denial: ``authorization_denied``.
+        On test-mode mismatch: ``safety_violation``.
+        On unknown ``identifier``: ``not_found``.
+        On CN save failure: ``unknown``.
+    """
+    if not identifier or not identifier.strip():
+        return _validation_error("identifier must be a non-empty string")
+    if not new_name or not new_name.strip():
+        return _validation_error("new_name must be a non-empty string")
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    safety_err = check_test_mode_safety(
+        "rename_group", group=group_identifier
+    )
+    if safety_err is not None:
+        return safety_err
+
+    try:
+        group = connector._run_cn_rename_group(
+            identifier=identifier, new_name=new_name
+        )
+    except ContactsNotFoundError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_type": "not_found",
+        }
+    except Exception as exc:
+        logger.error("rename_group failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"rename_group failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    return {"success": True, "group": group}
+
+
+@mcp.tool()
+def delete_group(
+    identifier: str,
+    group_identifier: str | None = None,
+) -> dict[str, Any]:
+    """Delete an existing contact group.
+
+    **v0.3.0 only allows delete in test mode** — the full destructive
+    UX (with confirmation prompts) ships in v0.4.0 (#36). Outside test
+    mode this returns a safety_violation error.
+
+    In test mode (``CONTACTS_TEST_MODE=true``), ``group_identifier``
+    must equal ``CONTACTS_TEST_GROUP``. Same posture as
+    ``delete_contact``.
+
+    Member contacts are NOT deleted by this operation — they keep
+    existing in the address book; they just lose membership in the
+    now-removed group.
+
+    Args:
+        identifier: The CN identifier of the group to delete.
+        group_identifier: Test-mode safety assertion. Required in test
+            mode (no other use).
+
+    Returns:
+        On success: ``{"success": True, "identifier": identifier}``.
+        On bad input: ``validation_error``.
+        On test mode off: ``safety_violation``.
+        On TCC denial: ``authorization_denied``.
+        On unknown ``identifier``: ``not_found``.
+        On CN save failure: ``unknown``.
+    """
+    if not identifier or not identifier.strip():
+        return _validation_error("identifier must be a non-empty string")
+
+    require_err = require_test_mode_for("delete_group")
+    if require_err is not None:
+        return require_err
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    safety_err = check_test_mode_safety(
+        "delete_group", group=group_identifier
+    )
+    if safety_err is not None:
+        return safety_err
+
+    try:
+        connector._run_cn_delete_group(identifier=identifier)
+    except ContactsNotFoundError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_type": "not_found",
+        }
+    except Exception as exc:
+        logger.error("delete_group failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"delete_group failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    return {"success": True, "identifier": identifier}
 
 
 def main() -> None:

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -1751,6 +1751,263 @@ def test_delete_contact_save_failure_raises(
 
 
 # ---------------------------------------------------------------------------
+# _run_cn_create_group / _run_cn_rename_group / _run_cn_delete_group
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_contacts_for_group_crud(
+    monkeypatch: pytest.MonkeyPatch,
+    fetched_group: MagicMock | None = None,
+    new_group_id: str = "NEW-GROUP-ID:ABGroup",
+    new_group_name: str = "Probe Group",
+    container_results: list[MagicMock] | None = None,
+    save_succeeds: bool = True,
+    fake_save_error: Any | None = None,
+) -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Install a fake `Contacts` module for group CRUD tests.
+
+    The store's ``groupsMatchingPredicate_error_`` returns
+    ``([fetched_group], None)`` if ``fetched_group`` is non-None,
+    otherwise ``([], None)`` so ``_run_cn_fetch_group`` returns None.
+
+    ``container_results`` powers the post-save container_id resolution
+    in ``_resolve_container_id``. Defaults to a single fake container
+    with identifier "DEFAULT-CONT:ABAccount".
+
+    Returns (store_instance, save_request_instance, new_mutable_instance).
+    The new_mutable_instance is what CNMutableGroup.alloc().init() returns —
+    callers can inspect ``setName_`` calls on it.
+    """
+    fake_contacts = types.ModuleType("Contacts")
+
+    new_mutable = MagicMock(name="new_mutable_group")
+    new_mutable.identifier.return_value = new_group_id
+    new_mutable.name.return_value = new_group_name
+    cn_mutable_group_class = MagicMock(name="CNMutableGroup")
+    cn_mutable_group_class.alloc.return_value.init.return_value = new_mutable
+    fake_contacts.CNMutableGroup = cn_mutable_group_class  # type: ignore[attr-defined]
+
+    cn_group_class = MagicMock(name="CNGroup")
+    cn_group_class.predicateForGroupsWithIdentifiers_.return_value = "GROUP_PRED"
+    fake_contacts.CNGroup = cn_group_class  # type: ignore[attr-defined]
+
+    cn_container_class = MagicMock(name="CNContainer")
+    cn_container_class.predicateForContainerOfGroupWithIdentifier_.return_value = (
+        "CONTAINER_PRED"
+    )
+    fake_contacts.CNContainer = cn_container_class  # type: ignore[attr-defined]
+
+    save_req = MagicMock(name="save_request")
+    cn_save_request_class = MagicMock(name="CNSaveRequest")
+    cn_save_request_class.alloc.return_value.init.return_value = save_req
+    fake_contacts.CNSaveRequest = cn_save_request_class  # type: ignore[attr-defined]
+
+    store_instance = MagicMock(name="store_instance")
+    if fetched_group is None:
+        store_instance.groupsMatchingPredicate_error_.return_value = (
+            [],
+            None,
+        )
+    else:
+        store_instance.groupsMatchingPredicate_error_.return_value = (
+            [fetched_group],
+            None,
+        )
+    store_instance.executeSaveRequest_error_.return_value = (
+        save_succeeds,
+        fake_save_error,
+    )
+    if container_results is None:
+        default_container = MagicMock(name="default_container")
+        default_container.identifier.return_value = "DEFAULT-CONT:ABAccount"
+        container_results = [default_container]
+    store_instance.containersMatchingPredicate_error_.return_value = (
+        container_results,
+        None,
+    )
+
+    cn_store_class = MagicMock(name="CNContactStore")
+    cn_store_class.alloc.return_value.init.return_value = store_instance
+    fake_contacts.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+    fake_contacts.CNEntityTypeContacts = 0  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "Contacts", fake_contacts)
+    return store_instance, save_req, new_mutable
+
+
+# ----- _run_cn_create_group ---------------------------------------------------
+
+
+def test_create_group_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    store, save_req, new_mutable = _install_fake_contacts_for_group_crud(
+        monkeypatch,
+        new_group_id="GRP-1:ABGroup",
+        new_group_name="MyGroup",
+    )
+    connector = ContactsConnector()
+    result = connector._run_cn_create_group(
+        name="MyGroup", container_identifier=None
+    )
+    assert result == {
+        "id": "GRP-1:ABGroup",
+        "name": "MyGroup",
+        "container_id": "DEFAULT-CONT:ABAccount",
+    }
+    new_mutable.setName_.assert_called_once_with("MyGroup")
+    save_req.addGroup_toContainerWithIdentifier_.assert_called_once_with(
+        new_mutable, None
+    )
+    store.executeSaveRequest_error_.assert_called_once()
+
+
+def test_create_group_with_explicit_container_passes_uuid_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, save_req, new_mutable = _install_fake_contacts_for_group_crud(monkeypatch)
+    connector = ContactsConnector()
+    connector._run_cn_create_group(
+        name="X", container_identifier="GMAIL-UUID:ABAccount"
+    )
+    args, _ = save_req.addGroup_toContainerWithIdentifier_.call_args
+    assert args[0] is new_mutable
+    assert args[1] == "GMAIL-UUID:ABAccount"
+
+
+def test_create_group_falls_back_to_empty_container_id_when_lookup_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_contacts_for_group_crud(
+        monkeypatch, container_results=[]
+    )
+    connector = ContactsConnector()
+    result = connector._run_cn_create_group(
+        name="MyGroup", container_identifier=None
+    )
+    assert result["container_id"] == ""
+
+
+def test_create_group_save_failure_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    err = MagicMock(name="NSError(save)")
+    err.__str__.return_value = "create boom"
+    _install_fake_contacts_for_group_crud(
+        monkeypatch, save_succeeds=False, fake_save_error=err
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_create_group(name="X", container_identifier=None)
+    assert "CN group create failed" in str(exc_info.value)
+    assert "create boom" in str(exc_info.value)
+
+
+# ----- _run_cn_rename_group ---------------------------------------------------
+
+
+def test_rename_group_raises_not_found_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, save_req, _ = _install_fake_contacts_for_group_crud(
+        monkeypatch, fetched_group=None
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsNotFoundError):
+        connector._run_cn_rename_group("MISSING", "Newname")
+    save_req.updateGroup_.assert_not_called()
+    store.executeSaveRequest_error_.assert_not_called()
+
+
+def test_rename_group_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    existing = MagicMock(name="existing_group")
+    mutable_copy = MagicMock(name="mutable_copy")
+    mutable_copy.name.return_value = "Updated Name"
+    existing.mutableCopy.return_value = mutable_copy
+    store, save_req, _ = _install_fake_contacts_for_group_crud(
+        monkeypatch, fetched_group=existing
+    )
+    connector = ContactsConnector()
+    result = connector._run_cn_rename_group("GRP-1:ABGroup", "Updated Name")
+    assert result == {
+        "id": "GRP-1:ABGroup",
+        "name": "Updated Name",
+        "container_id": "DEFAULT-CONT:ABAccount",
+    }
+    mutable_copy.setName_.assert_called_once_with("Updated Name")
+    save_req.updateGroup_.assert_called_once_with(mutable_copy)
+    store.executeSaveRequest_error_.assert_called_once()
+
+
+def test_rename_group_save_failure_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = MagicMock(name="existing_group")
+    existing.mutableCopy.return_value = MagicMock(name="mutable_copy")
+    err = MagicMock(name="NSError(save)")
+    err.__str__.return_value = "rename boom"
+    _install_fake_contacts_for_group_crud(
+        monkeypatch,
+        fetched_group=existing,
+        save_succeeds=False,
+        fake_save_error=err,
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_rename_group("GRP-1", "X")
+    assert "CN group rename failed" in str(exc_info.value)
+    assert "rename boom" in str(exc_info.value)
+
+
+# ----- _run_cn_delete_group ---------------------------------------------------
+
+
+def test_delete_group_raises_not_found_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, save_req, _ = _install_fake_contacts_for_group_crud(
+        monkeypatch, fetched_group=None
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsNotFoundError):
+        connector._run_cn_delete_group("MISSING")
+    save_req.deleteGroup_.assert_not_called()
+    store.executeSaveRequest_error_.assert_not_called()
+
+
+def test_delete_group_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    existing = MagicMock(name="existing_group")
+    mutable_copy = MagicMock(name="mutable_copy")
+    existing.mutableCopy.return_value = mutable_copy
+    store, save_req, _ = _install_fake_contacts_for_group_crud(
+        monkeypatch, fetched_group=existing
+    )
+    connector = ContactsConnector()
+    result = connector._run_cn_delete_group("GRP-1:ABGroup")
+    assert result == "GRP-1:ABGroup"
+    save_req.deleteGroup_.assert_called_once_with(mutable_copy)
+    store.executeSaveRequest_error_.assert_called_once()
+
+
+def test_delete_group_save_failure_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = MagicMock(name="existing_group")
+    existing.mutableCopy.return_value = MagicMock(name="mutable_copy")
+    err = MagicMock(name="NSError(save)")
+    err.__str__.return_value = "delete boom"
+    _install_fake_contacts_for_group_crud(
+        monkeypatch,
+        fetched_group=existing,
+        save_succeeds=False,
+        fake_save_error=err,
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_delete_group("GRP-1")
+    assert "CN group delete failed" in str(exc_info.value)
+    assert "delete boom" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
 # _run_cn_list_containers
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -17,7 +17,9 @@ from apple_contacts_mcp.server import (
     add_contact_to_group,
     check_authorization,
     create_contact,
+    create_group,
     delete_contact,
+    delete_group,
     export_vcard,
     get_contact,
     get_contacts_in_group,
@@ -27,6 +29,7 @@ from apple_contacts_mcp.server import (
     list_groups,
     read_note,
     remove_contact_from_group,
+    rename_group,
     search_contacts,
     update_contact,
     write_note,
@@ -2003,3 +2006,291 @@ class TestImportVcardErrors:
         assert result["success"] is False
         assert result["error_type"] == "unknown"
         assert "save failed" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# create_group
+# ---------------------------------------------------------------------------
+
+
+_NEW_GROUP_DICT = {
+    "id": "NEW-GRP:ABGroup",
+    "name": "MyGroup",
+    "container_id": "ICLOUD:ABAccount",
+}
+
+
+class TestCreateGroupValidation:
+    @pytest.mark.parametrize("name", ["", "   ", "\t"])
+    def test_blank_name_returns_validation_error(self, name: str) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = create_group(name=name)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_authorization_status.assert_not_called()
+
+
+class TestCreateGroupAuthFlow:
+    def test_auth_denied_passthrough_skips_create(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "denied"
+            result = create_group(name="X")
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        mock_connector._run_cn_create_group.assert_not_called()
+
+
+class TestCreateGroupTestModeSafety:
+    def test_test_mode_without_group_arg_blocked(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = create_group(name="X")
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        mock_connector._run_cn_create_group.assert_not_called()
+
+    def test_test_mode_with_matching_group_proceeds(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_group.return_value = _NEW_GROUP_DICT
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = create_group(
+                    name="X", group_identifier="MCP-Test"
+                )
+        assert result == {"success": True, "group": _NEW_GROUP_DICT}
+
+
+class TestCreateGroupHappyPath:
+    def test_returns_group_dict_from_connector(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_group.return_value = _NEW_GROUP_DICT
+            result = create_group(name="MyGroup")
+        assert result == {"success": True, "group": _NEW_GROUP_DICT}
+        kwargs = mock_connector._run_cn_create_group.call_args.kwargs
+        assert kwargs["name"] == "MyGroup"
+        assert kwargs["container_identifier"] is None
+
+    def test_passes_container_identifier_through(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_group.return_value = _NEW_GROUP_DICT
+            create_group(
+                name="MyGroup",
+                container_identifier="GMAIL:ABAccount",
+            )
+        kwargs = mock_connector._run_cn_create_group.call_args.kwargs
+        assert kwargs["container_identifier"] == "GMAIL:ABAccount"
+
+
+class TestCreateGroupErrors:
+    def test_save_failure_returns_unknown(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_group.side_effect = ContactsError(
+                "save boom"
+            )
+            result = create_group(name="X")
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "save boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# rename_group
+# ---------------------------------------------------------------------------
+
+
+_RENAMED_GROUP_DICT = {
+    "id": "GRP-1:ABGroup",
+    "name": "Renamed",
+    "container_id": "ICLOUD:ABAccount",
+}
+
+
+class TestRenameGroupValidation:
+    @pytest.mark.parametrize("identifier", ["", "   ", "\t"])
+    def test_blank_identifier_returns_validation_error(
+        self, identifier: str
+    ) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = rename_group(identifier=identifier, new_name="X")
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_authorization_status.assert_not_called()
+
+    @pytest.mark.parametrize("new_name", ["", "   ", "\t"])
+    def test_blank_new_name_returns_validation_error(
+        self, new_name: str
+    ) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = rename_group(identifier="GRP-1", new_name=new_name)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_authorization_status.assert_not_called()
+
+
+class TestRenameGroupAuthFlow:
+    def test_auth_denied_passthrough_skips_rename(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "denied"
+            result = rename_group(identifier="GRP-1", new_name="X")
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        mock_connector._run_cn_rename_group.assert_not_called()
+
+
+class TestRenameGroupTestModeSafety:
+    def test_test_mode_without_group_arg_blocked(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = rename_group(identifier="GRP-1", new_name="X")
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        mock_connector._run_cn_rename_group.assert_not_called()
+
+    def test_test_mode_with_matching_group_proceeds(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_rename_group.return_value = _RENAMED_GROUP_DICT
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = rename_group(
+                    identifier="GRP-1",
+                    new_name="Renamed",
+                    group_identifier="MCP-Test",
+                )
+        assert result == {"success": True, "group": _RENAMED_GROUP_DICT}
+
+
+class TestRenameGroupErrors:
+    def test_not_found_from_connector(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_rename_group.side_effect = (
+                ContactsNotFoundError("Group not found: 'BAD'")
+            )
+            result = rename_group(identifier="BAD", new_name="X")
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+
+    def test_save_failure_returns_unknown(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_rename_group.side_effect = ContactsError(
+                "save boom"
+            )
+            result = rename_group(identifier="GRP-1", new_name="X")
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "save boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# delete_group
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteGroupValidation:
+    def test_empty_identifier_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = delete_group(identifier="")
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_authorization_status.assert_not_called()
+
+
+class TestDeleteGroupRequiresTestMode:
+    def test_test_mode_off_returns_safety_violation(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = delete_group(identifier="GRP-1")
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        assert "CONTACTS_TEST_MODE" in result["error"]
+        # Auth was NOT triggered (no TCC prompt for an op we refused).
+        mock_connector._run_cn_authorization_status.assert_not_called()
+        mock_connector._run_cn_delete_group.assert_not_called()
+
+
+class TestDeleteGroupTestGroupGate:
+    def test_test_mode_on_no_group_arg_blocked(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = delete_group(identifier="GRP-1")
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        mock_connector._run_cn_delete_group.assert_not_called()
+
+    def test_test_mode_on_with_matching_group_proceeds(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_delete_group.return_value = "GRP-1"
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = delete_group(
+                    identifier="GRP-1", group_identifier="MCP-Test"
+                )
+        assert result == {"success": True, "identifier": "GRP-1"}
+
+
+class TestDeleteGroupErrors:
+    def test_not_found_from_connector(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_delete_group.side_effect = (
+                ContactsNotFoundError("Group not found: 'BAD'")
+            )
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = delete_group(
+                    identifier="BAD", group_identifier="MCP-Test"
+                )
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+
+    def test_save_failure_returns_unknown(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_delete_group.side_effect = ContactsError(
+                "save boom"
+            )
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = delete_group(
+                    identifier="GRP-1", group_identifier="MCP-Test"
+                )
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "save boom" in result["error"]


### PR DESCRIPTION
## Summary

Closes the group surface that v0.2.0 left half-finished. Read (`list_groups`, `get_contacts_in_group`) and membership writes (`add_contact_to_group`, `remove_contact_from_group`) shipped earlier; this PR adds the three missing CRUD primitives on groups themselves.

### New tools

| Tool | Connector primitive | Test-mode posture |
|---|---|---|
| `create_group(name, container_identifier=None)` | `CNMutableGroup` + `addGroup:toContainerWithIdentifier:` | `check_test_mode_safety` (matches `create_contact`) |
| `rename_group(identifier, new_name)` | fetch + `mutableCopy` + `setName_` + `updateGroup_` | `check_test_mode_safety` (matches `update_contact`) |
| `delete_group(identifier)` | fetch + `deleteGroup_` | `require_test_mode_for` + `check_test_mode_safety` (matches `delete_contact`) |

All three accept a `group_identifier` parameter that's purely the test-mode assertion (must match `CONTACTS_TEST_GROUP` in test mode; freely allowed outside). For `rename_group` / `delete_group`, the asserted scope is independent of the actual target — a test harness can rename/delete any group as long as it operates within the test-group scope.

`delete_group` is **test-mode-only in v0.3.x** until the confirmation UX (#36) ships in v0.4.0 — same conservative posture as `delete_contact`.

### Drive-by: stale `#24` references fixed

Two user-visible messages cited `(#24)` for the v0.4.0 confirmation UX, but #24 is **this** issue (Group CRUD); the actual confirmation issue is #36. Fixed in [security.py:172](src/apple_contacts_mcp/security.py#L172) and [server.py:843–844](src/apple_contacts_mcp/server.py#L843). Touched the same destructive-op infrastructure anyway.

### Behavior notes

- `delete_group` does NOT cascade-delete members. Member contacts remain in the address book; they just lose membership in the now-removed group. Documented in the tool docstring and TOOLS.md.
- `create_group` defaults to the user's default container (typically iCloud) unless `container_identifier` is passed; uses the same multi-container primitive #26 validated.
- All three are registered in `DESTRUCTIVE_OPERATIONS` — the parameterized test_security coverage auto-picked them up (3 extra tests).

### Validation

- 423 unit tests pass (387 baseline + 36 new); coverage **97.81%**.
- `check_complexity.sh` ✓ — exits 0; no functions exceed CC=20.
- `check_client_server_parity.sh` ✓ — 19 tools wired; every connector method has a server tool.
- `check_version_sync.sh` ✓.

## Test plan

- [ ] CI green on the honest complexity gate.
- [ ] Manual smoke (`CONTACTS_TEST_MODE=true CONTACTS_TEST_GROUP=MCP-Test`):
  - `create_group(name="MCP-Test-Sub", group_identifier="MCP-Test")` → group visible under iCloud in Contacts.app.
  - `rename_group(identifier=<id>, new_name="MCP-Test-Sub-2", group_identifier="MCP-Test")` → updated name visible.
  - `delete_group(identifier=<id>, group_identifier="MCP-Test")` → group disappears; member contacts (if any) survive.
  - `delete_group(...)` WITHOUT test mode → `safety_violation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)