### PR TITLE
feat: read_photo + write_photo with magic-byte format detection (closes #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `rename_group(identifier, new_name)` — rename an existing group via `CNSaveRequest.updateGroup:`. Returns the updated `{id, name, container_id}`. Test-mode gated like `update_contact` (#24).
 - `delete_group(identifier)` — delete a group via `CNSaveRequest.deleteGroup:`. **Test-mode-only in v0.3.x** (same posture as `delete_contact`); confirmation UX ships in v0.4.0 (#36). Member contacts are NOT deleted — they remain in the address book, just lose membership in the now-removed group (#24).
 - `create_group` / `rename_group` / `delete_group` added to `DESTRUCTIVE_OPERATIONS` so the test-mode safety gate covers them.
+- `read_photo(identifier)` — read a contact's photo. Returns `{image_data: <base64>, format: "jpeg" | "png" | "gif" | "heic" | "unknown", size_bytes: N}` when a photo is set; `{image_data: null, format: null, size_bytes: 0}` when the contact exists but has no photo. The contact-not-found case dispatches `not_found` distinctly. Per the gap analysis gotcha, the connector always checks `imageDataAvailable()` before calling `imageData()` (#25).
+- `write_photo(identifier, image_data, group_identifier=None)` — set or clear a contact's photo via `setImageData_`. `image_data` is base64-encoded; `None` clears. Permissive on format — Apple is the authority on accepted bytes. Test-mode gated like `update_contact` (#25).
+- `detect_image_format(bytes) -> str` helper in `utils.py` — magic-byte detector returning one of `"jpeg"` / `"png"` / `"gif"` / `"heic"` / `"unknown"`. The HEIC bucket covers all HEIF-family ISOBMFF brands Apple emits. Pure function; no PyObjC dependency.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Model Context Protocol server for Apple Contacts on macOS.
 - `update_contact` — partial-field update.
 - `delete_contact` — test-mode-only in v0.2.x; full destructive UX ships in v0.4.0.
 - `read_note` / `write_note` — note field via AppleScript fallback (entitlement-gated in CN).
+- `read_photo` / `write_photo` — contact photo as base64-encoded bytes; read returns the detected format (JPEG/PNG/HEIC/GIF).
 - `list_groups` / `get_contacts_in_group` — group read.
 - `add_contact_to_group` / `remove_contact_from_group` — group membership.
 - `create_group` / `rename_group` / `delete_group` — group CRUD. `delete_group` is test-mode-only in v0.3.x; full destructive UX with confirmation prompts ships in v0.4.0.

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -3,7 +3,7 @@
 Reference for every MCP tool the apple-contacts-mcp server exposes.
 
 **Version:** v0.2.1 (tracks the package version)
-**Tools:** 19
+**Tools:** 21
 
 The source-of-truth for tool behavior is the docstrings in
 [src/apple_contacts_mcp/server.py](../../src/apple_contacts_mcp/server.py)
@@ -761,6 +761,84 @@ def list_containers() -> dict[str, Any]
 - Hard cap at 10 (containers per user are typically <5). `count == limit` indicates the cap was hit.
 - Read-only; no test-mode gating.
 - Empirical basis for the multi-container write path: [`docs/research/multi-container-write-decision.md`](../research/multi-container-write-decision.md).
+
+### read_photo
+
+Read a contact's photo. Returns base64-encoded bytes plus the detected image format.
+
+```python
+def read_photo(identifier: str) -> dict[str, Any]
+```
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `identifier` | str | — | The contact's CN identifier. |
+
+**Returns:**
+
+```jsonc
+// Contact exists, photo set
+{
+  "success": true,
+  "identifier": "ABCD-…",
+  "image_data": "<base64-encoded bytes>",
+  "format": "jpeg",
+  "size_bytes": 12345
+}
+
+// Contact exists, no photo set — distinct from not_found
+{
+  "success": true,
+  "identifier": "ABCD-…",
+  "image_data": null,
+  "format": null,
+  "size_bytes": 0
+}
+```
+
+**Error types:** `validation_error`, `authorization_denied`, `not_found`, `unknown`.
+
+**Notes:**
+- **Binary transport:** `image_data` is base64-encoded (`base64.b64encode(bytes).decode("ascii")`). Callers decode via `base64.b64decode(image_data)` to recover the raw bytes.
+- **Format detection** runs magic-byte detection on the raw bytes; the result is one of `"jpeg"`, `"png"`, `"gif"`, `"heic"`, or `"unknown"`. The HEIC bucket covers the HEIF-family ISOBMFF brands Apple emits (heic, heix, heif, hevc, hevx, mif1, msf1).
+- **The no-photo case is a SUCCESS**, not `not_found`. Callers must check `image_data is not None` to detect "has photo," not key presence.
+- Per the gap analysis gotcha, the connector always checks `imageDataAvailable()` before calling `imageData()` — directly reading on a photo-less contact misbehaves empirically.
+
+### write_photo
+
+Set or clear a contact's photo.
+
+```python
+def write_photo(
+    identifier: str,
+    image_data: str | None,
+    group_identifier: str | None = None,
+) -> dict[str, Any]
+```
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `identifier` | str | — | The contact's CN identifier. |
+| `image_data` | str \| None | — | Base64-encoded image bytes (JPEG/PNG/HEIC supported by Apple). `null` clears the existing photo. |
+| `group_identifier` | str \| None | None | Test-mode safety assertion. Required in test mode (must match `CONTACTS_TEST_GROUP`); ignored otherwise. |
+
+**Returns:**
+
+```jsonc
+{"success": true, "identifier": "ABCD-…"}
+```
+
+**Error types:** `validation_error`, `authorization_denied`, `safety_violation`, `not_found`, `unknown`.
+
+**Notes:**
+- **Destructive (test-mode gated).** Same posture as `update_contact`.
+- **Binary transport:** caller supplies base64-encoded text via `base64.b64encode(bytes).decode("ascii")`. The tool decodes via `base64.b64decode(..., validate=True)` and surfaces decode errors as `validation_error`.
+- **Permissive on format:** the tool does not pre-validate that the bytes are a recognized image format. Apple is the authority — if it rejects the bytes, `CNSaveRequest` fails and we surface `unknown`.
+- **`image_data=null` clears the photo** — the standard way to remove a contact's existing image. The clear path is atomic just like a write.
 
 ### create_group
 

--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -943,6 +943,75 @@ class ContactsConnector:
             )
         return out
 
+    def _run_cn_read_photo(
+        self, identifier: str
+    ) -> dict[str, Any] | None:
+        """Read a contact's photo via CN's ``imageData()``.
+
+        Returns ``None`` if no contact matches (mirrors
+        ``_run_cn_unified_contact``'s missing-contact contract).
+        Otherwise returns ``{"available": bool, "image_data": bytes}``.
+        When ``available`` is False, ``image_data`` is ``b""``.
+
+        Always checks ``imageDataAvailable()`` BEFORE calling ``imageData()`` —
+        per the gap analysis, calling ``imageData()`` on a photo-less contact
+        is documented to misbehave.
+        """
+        from Contacts import (
+            CNContactImageDataAvailableKey,
+            CNContactImageDataKey,
+        )
+
+        keys = [CNContactImageDataKey, CNContactImageDataAvailableKey]
+        store = self._get_store()
+        contact, _err = store.unifiedContactWithIdentifier_keysToFetch_error_(
+            identifier, keys, None
+        )
+        if contact is None:
+            return None
+
+        if not bool(contact.imageDataAvailable()):
+            return {"available": False, "image_data": b""}
+
+        raw = contact.imageData()
+        # PyObjC bridges NSData → bytes for slicing/len; force-cast in case.
+        return {"available": True, "image_data": bytes(raw) if raw else b""}
+
+    def _run_cn_write_photo(
+        self, identifier: str, image_data: bytes | None
+    ) -> str:
+        """Set or clear a contact's photo via CN's ``setImageData_``.
+
+        ``image_data=None`` clears the photo. Otherwise pass raw bytes;
+        PyObjC bridges ``bytes`` → ``NSData`` automatically. Apple is
+        the authority on what bytes it accepts — if the bytes are
+        rejected, ``executeSaveRequest:error:`` returns False and we
+        raise ``ContactsError`` (server layer surfaces ``unknown``).
+
+        Returns the identifier (echo).
+        """
+        from Contacts import CNContactImageDataKey, CNSaveRequest
+
+        store = self._get_store()
+        contact, _err = store.unifiedContactWithIdentifier_keysToFetch_error_(
+            identifier, [CNContactImageDataKey], None
+        )
+        if contact is None:
+            raise ContactsNotFoundError(
+                f"Contact not found: {identifier!r}"
+            )
+
+        mutable = contact.mutableCopy()
+        mutable.setImageData_(image_data)
+
+        save_req = CNSaveRequest.alloc().init()
+        save_req.updateContact_(mutable)
+        ok, err = store.executeSaveRequest_error_(save_req, None)
+        if not ok:
+            raise ContactsError(f"CN photo write failed: {err}")
+
+        return identifier
+
     def _run_cn_unified_contact(
         self, identifier: str
     ) -> dict[str, Any] | None:

--- a/src/apple_contacts_mcp/security.py
+++ b/src/apple_contacts_mcp/security.py
@@ -42,6 +42,7 @@ DESTRUCTIVE_OPERATIONS: frozenset[str] = frozenset(
         "create_group",
         "rename_group",
         "delete_group",
+        "write_photo",
     }
 )
 """Operations gated by `check_test_mode_safety`.

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
 from typing import Any, cast
 
@@ -10,6 +12,7 @@ from fastmcp import FastMCP
 from .contacts_connector import ContactsConnector, SearchField
 from .exceptions import ContactsError, ContactsNotFoundError, ContactsTimeoutError
 from .security import check_test_mode_safety, require_test_mode_for
+from .utils import detect_image_format
 
 logging.basicConfig(
     level=logging.INFO,
@@ -1161,6 +1164,154 @@ def write_note(
         return {
             "success": False,
             "error": f"write_note failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    return {"success": True, "identifier": identifier}
+
+
+@mcp.tool()
+def read_photo(identifier: str) -> dict[str, Any]:
+    """Read a contact's photo. Returns base64-encoded bytes + detected format.
+
+    The photo is transported as base64-encoded text — JSON-safe over the
+    MCP wire. Callers decode via ``base64.b64decode(image_data)``.
+
+    The contact-exists-but-no-photo case is a SUCCESS (``image_data:
+    null``, ``format: null``, ``size_bytes: 0``) — distinct from
+    ``not_found``, which means the identifier didn't match any contact.
+
+    Args:
+        identifier: The contact's CN identifier.
+
+    Returns:
+        On success (photo set): ``{"success": True, "identifier": ...,
+        "image_data": "<base64>", "format": "jpeg" | "png" | "heic" |
+        "gif" | "unknown", "size_bytes": <int>}``.
+        On success (no photo set): ``{"success": True, "identifier":
+        ..., "image_data": null, "format": null, "size_bytes": 0}``.
+        On bad input: ``validation_error``.
+        On TCC denial: ``authorization_denied``.
+        On unknown identifier: ``not_found``.
+        On unexpected failure: ``unknown``.
+    """
+    if not identifier or not identifier.strip():
+        return _validation_error("identifier must be a non-empty string")
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    try:
+        photo = connector._run_cn_read_photo(identifier)
+    except Exception as exc:
+        logger.error("read_photo failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"read_photo failed: {exc}",
+            "error_type": "unknown",
+        }
+
+    if photo is None:
+        return {
+            "success": False,
+            "error": f"Contact not found: {identifier!r}",
+            "error_type": "not_found",
+        }
+
+    if not photo["available"]:
+        return {
+            "success": True,
+            "identifier": identifier,
+            "image_data": None,
+            "format": None,
+            "size_bytes": 0,
+        }
+
+    raw = photo["image_data"]
+    return {
+        "success": True,
+        "identifier": identifier,
+        "image_data": base64.b64encode(raw).decode("ascii"),
+        "format": detect_image_format(raw),
+        "size_bytes": len(raw),
+    }
+
+
+@mcp.tool()
+def write_photo(
+    identifier: str,
+    image_data: str | None,
+    group_identifier: str | None = None,
+) -> dict[str, Any]:
+    """Set or clear a contact's photo.
+
+    ``image_data`` is **base64-encoded** input — JSON-safe transport for
+    binary. ``image_data=None`` clears the photo. Apple is the authority
+    on accepted formats; bytes that Apple rejects surface as ``unknown``
+    rather than ``validation_error``.
+
+    Destructive (test-mode gated): in test mode,
+    ``group_identifier`` must match ``CONTACTS_TEST_GROUP``.
+
+    Args:
+        identifier: The contact's CN identifier.
+        image_data: Base64-encoded image bytes (JPEG/PNG/HEIC). ``None``
+            clears the existing photo.
+        group_identifier: Test-mode safety assertion. Required in test
+            mode; ignored otherwise.
+
+    Returns:
+        On success: ``{"success": True, "identifier": identifier}``.
+        On bad input (empty identifier or bad base64): ``validation_error``.
+        On TCC denial: ``authorization_denied``.
+        On test-mode mismatch: ``safety_violation``.
+        On unknown identifier: ``not_found``.
+        On CN save failure: ``unknown``.
+    """
+    if not identifier or not identifier.strip():
+        return _validation_error("identifier must be a non-empty string")
+
+    decoded: bytes | None
+    if image_data is None:
+        decoded = None
+    else:
+        if not isinstance(image_data, str):
+            return _validation_error(
+                "image_data must be a base64-encoded string or null"
+            )
+        try:
+            decoded = base64.b64decode(image_data, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            return _validation_error(
+                f"image_data is not valid base64: {exc}"
+            )
+
+    auth_err = _require_contacts_authorization()
+    if auth_err is not None:
+        return auth_err
+
+    safety_err = check_test_mode_safety(
+        "write_photo", group=group_identifier
+    )
+    if safety_err is not None:
+        return safety_err
+
+    try:
+        connector._run_cn_write_photo(
+            identifier=identifier, image_data=decoded
+        )
+    except ContactsNotFoundError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "error_type": "not_found",
+        }
+    except Exception as exc:
+        logger.error("write_photo failed: %s", exc)
+        return {
+            "success": False,
+            "error": f"write_photo failed: {exc}",
             "error_type": "unknown",
         }
 

--- a/src/apple_contacts_mcp/utils.py
+++ b/src/apple_contacts_mcp/utils.py
@@ -35,6 +35,33 @@ _HUMAN_LABEL_TO_APPLE_TOKEN: dict[str, str] = {
 }
 
 
+_HEIC_FTYP_BRANDS: frozenset[bytes] = frozenset(
+    {b"heic", b"heix", b"heif", b"hevc", b"hevx", b"mif1", b"msf1"}
+)
+
+
+def detect_image_format(data: bytes) -> str:
+    """Identify an image format from its leading magic bytes.
+
+    Returns one of ``"jpeg"``, ``"png"``, ``"gif"``, ``"heic"``, or
+    ``"unknown"``. Pure function; no PyObjC dependency. Robust against
+    short / empty input — never raises.
+
+    ``"heic"`` covers the wider HEIF-family ISOBMFF brands Apple emits
+    (heic, heix, heif, hevc, hevx, mif1, msf1) — they're all "HEIF-flavored
+    bytes" from a caller's perspective.
+    """
+    if len(data) >= 3 and data[:3] == b"\xff\xd8\xff":
+        return "jpeg"
+    if len(data) >= 8 and data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "png"
+    if len(data) >= 4 and data[:4] == b"GIF8":
+        return "gif"
+    if len(data) >= 12 and data[4:8] == b"ftyp" and data[8:12] in _HEIC_FTYP_BRANDS:
+        return "heic"
+    return "unknown"
+
+
 def label_to_apple_token(label: str) -> str:
     """Translate a label input to the form Contacts.framework expects.
 

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -1751,6 +1751,180 @@ def test_delete_contact_save_failure_raises(
 
 
 # ---------------------------------------------------------------------------
+# _run_cn_read_photo / _run_cn_write_photo
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_contacts_for_photo(
+    monkeypatch: pytest.MonkeyPatch,
+    fetched_contact: MagicMock | None = None,
+    save_succeeds: bool = True,
+    fake_save_error: Any | None = None,
+) -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Install a fake `Contacts` module covering read/write photo paths.
+
+    Returns (store_instance, save_request_instance, mutable_instance).
+    For read tests, mutable_instance is unused. For write tests with a
+    real fetched_contact, mutable_instance is what mutableCopy() returns;
+    callers can inspect setImageData_ calls on it.
+    """
+    fake_contacts = types.ModuleType("Contacts")
+    fake_contacts.CNContactImageDataKey = "CNContactImageDataKey"  # type: ignore[attr-defined]
+    fake_contacts.CNContactImageDataAvailableKey = (  # type: ignore[attr-defined]
+        "CNContactImageDataAvailableKey"
+    )
+
+    save_req = MagicMock(name="save_request")
+    cn_save_request_class = MagicMock(name="CNSaveRequest")
+    cn_save_request_class.alloc.return_value.init.return_value = save_req
+    fake_contacts.CNSaveRequest = cn_save_request_class  # type: ignore[attr-defined]
+
+    store_instance = MagicMock(name="store_instance")
+    mutable_instance = MagicMock(name="mutable_instance")
+    if fetched_contact is None:
+        store_instance.unifiedContactWithIdentifier_keysToFetch_error_.return_value = (
+            None,
+            MagicMock(name="NSError(not_found)"),
+        )
+    else:
+        store_instance.unifiedContactWithIdentifier_keysToFetch_error_.return_value = (
+            fetched_contact,
+            None,
+        )
+        fetched_contact.mutableCopy.return_value = mutable_instance
+    store_instance.executeSaveRequest_error_.return_value = (
+        save_succeeds,
+        fake_save_error,
+    )
+
+    cn_store_class = MagicMock(name="CNContactStore")
+    cn_store_class.alloc.return_value.init.return_value = store_instance
+    fake_contacts.CNContactStore = cn_store_class  # type: ignore[attr-defined]
+    fake_contacts.CNEntityTypeContacts = 0  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "Contacts", fake_contacts)
+    return store_instance, save_req, mutable_instance
+
+
+# ----- _run_cn_read_photo -----------------------------------------------------
+
+
+def test_read_photo_missing_contact_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_contacts_for_photo(monkeypatch, fetched_contact=None)
+    connector = ContactsConnector()
+    assert connector._run_cn_read_photo("MISSING") is None
+
+
+def test_read_photo_returns_empty_bytes_when_no_photo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """imageDataAvailable() is False → contract returns {available: False,
+    image_data: b''} WITHOUT calling imageData()."""
+    fetched = MagicMock(name="fetched")
+    fetched.imageDataAvailable.return_value = False
+    _install_fake_contacts_for_photo(monkeypatch, fetched_contact=fetched)
+    connector = ContactsConnector()
+    result = connector._run_cn_read_photo("ABCD")
+    assert result == {"available": False, "image_data": b""}
+    fetched.imageData.assert_not_called()
+
+
+def test_read_photo_returns_bytes_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetched = MagicMock(name="fetched")
+    fetched.imageDataAvailable.return_value = True
+    fetched.imageData.return_value = b"\xff\xd8\xfffake-jpeg"
+    _install_fake_contacts_for_photo(monkeypatch, fetched_contact=fetched)
+    connector = ContactsConnector()
+    result = connector._run_cn_read_photo("ABCD")
+    assert result == {
+        "available": True,
+        "image_data": b"\xff\xd8\xfffake-jpeg",
+    }
+
+
+def test_read_photo_handles_falsy_imagedata_defensively(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If imageDataAvailable() lies (True) but imageData() returns None,
+    we don't crash; we return empty bytes."""
+    fetched = MagicMock(name="fetched")
+    fetched.imageDataAvailable.return_value = True
+    fetched.imageData.return_value = None
+    _install_fake_contacts_for_photo(monkeypatch, fetched_contact=fetched)
+    connector = ContactsConnector()
+    result = connector._run_cn_read_photo("ABCD")
+    assert result == {"available": True, "image_data": b""}
+
+
+# ----- _run_cn_write_photo ----------------------------------------------------
+
+
+def test_write_photo_raises_not_found_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, save_req, _ = _install_fake_contacts_for_photo(
+        monkeypatch, fetched_contact=None
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsNotFoundError):
+        connector._run_cn_write_photo("MISSING", b"x")
+    save_req.updateContact_.assert_not_called()
+    store.executeSaveRequest_error_.assert_not_called()
+
+
+def test_write_photo_happy_path_sets_image_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetched = MagicMock(name="fetched")
+    store, save_req, mutable = _install_fake_contacts_for_photo(
+        monkeypatch, fetched_contact=fetched
+    )
+    connector = ContactsConnector()
+    payload = b"\xff\xd8\xfffake-jpeg"
+    result = connector._run_cn_write_photo("ABCD", payload)
+    assert result == "ABCD"
+    mutable.setImageData_.assert_called_once_with(payload)
+    save_req.updateContact_.assert_called_once_with(mutable)
+    store.executeSaveRequest_error_.assert_called_once()
+
+
+def test_write_photo_clear_passes_none_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetched = MagicMock(name="fetched")
+    _, _, mutable = _install_fake_contacts_for_photo(
+        monkeypatch, fetched_contact=fetched
+    )
+    connector = ContactsConnector()
+    result = connector._run_cn_write_photo("ABCD", None)
+    assert result == "ABCD"
+    mutable.setImageData_.assert_called_once_with(None)
+
+
+def test_write_photo_save_failure_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetched = MagicMock(name="fetched")
+    err = MagicMock(name="NSError(save)")
+    err.__str__.return_value = "photo boom"
+    _install_fake_contacts_for_photo(
+        monkeypatch,
+        fetched_contact=fetched,
+        save_succeeds=False,
+        fake_save_error=err,
+    )
+    connector = ContactsConnector()
+    with pytest.raises(ContactsError) as exc_info:
+        connector._run_cn_write_photo("ABCD", b"x")
+    assert "CN photo write failed" in str(exc_info.value)
+    assert "photo boom" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
 # _run_cn_create_group / _run_cn_rename_group / _run_cn_delete_group
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 from typing import Any
 from unittest.mock import patch
 
@@ -28,11 +29,13 @@ from apple_contacts_mcp.server import (
     list_containers,
     list_groups,
     read_note,
+    read_photo,
     remove_contact_from_group,
     rename_group,
     search_contacts,
     update_contact,
     write_note,
+    write_photo,
 )
 
 
@@ -2006,6 +2009,205 @@ class TestImportVcardErrors:
         assert result["success"] is False
         assert result["error_type"] == "unknown"
         assert "save failed" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# read_photo / write_photo
+# ---------------------------------------------------------------------------
+
+
+_JPEG_BYTES = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00fake-jpeg-payload"
+_JPEG_B64 = base64.b64encode(_JPEG_BYTES).decode("ascii")
+
+
+class TestReadPhotoValidation:
+    @pytest.mark.parametrize("identifier", ["", "   ", "\t"])
+    def test_blank_identifier_returns_validation_error(
+        self, identifier: str
+    ) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = read_photo(identifier=identifier)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_authorization_status.assert_not_called()
+
+
+class TestReadPhotoAuthFlow:
+    def test_auth_denied_passthrough_skips_read(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "denied"
+            result = read_photo(identifier="ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        mock_connector._run_cn_read_photo.assert_not_called()
+
+
+class TestReadPhotoHappyPath:
+    def test_returns_base64_encoded_jpeg(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_read_photo.return_value = {
+                "available": True,
+                "image_data": _JPEG_BYTES,
+            }
+            result = read_photo(identifier="ABCD")
+        assert result == {
+            "success": True,
+            "identifier": "ABCD",
+            "image_data": _JPEG_B64,
+            "format": "jpeg",
+            "size_bytes": len(_JPEG_BYTES),
+        }
+
+    def test_contact_without_photo_returns_null_image_data(self) -> None:
+        """Distinct from not_found: contact exists, photo unset."""
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_read_photo.return_value = {
+                "available": False,
+                "image_data": b"",
+            }
+            result = read_photo(identifier="ABCD")
+        assert result == {
+            "success": True,
+            "identifier": "ABCD",
+            "image_data": None,
+            "format": None,
+            "size_bytes": 0,
+        }
+
+    def test_unknown_format_still_succeeds(self) -> None:
+        """Caller gets whatever Apple stored, even if magic bytes don't match
+        a known image format. format='unknown' on the response is normal."""
+        weird = b"\x00\x01\x02\x03some-weird-format"
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_read_photo.return_value = {
+                "available": True,
+                "image_data": weird,
+            }
+            result = read_photo(identifier="ABCD")
+        assert result["success"] is True
+        assert result["format"] == "unknown"
+        assert result["size_bytes"] == len(weird)
+
+
+class TestReadPhotoNotFound:
+    def test_missing_contact_returns_not_found(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_read_photo.return_value = None
+            result = read_photo(identifier="BAD")
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+
+
+class TestReadPhotoErrors:
+    def test_unexpected_exception_returns_unknown(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_read_photo.side_effect = ContactsError(
+                "boom"
+            )
+            result = read_photo(identifier="ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "boom" in result["error"]
+
+
+class TestWritePhotoValidation:
+    def test_empty_identifier_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = write_photo(identifier="", image_data=_JPEG_B64)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_authorization_status.assert_not_called()
+
+    def test_invalid_base64_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            result = write_photo(identifier="ABCD", image_data="not-base64!!!")
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        assert "base64" in result["error"]
+        mock_connector._run_cn_authorization_status.assert_not_called()
+
+    def test_non_string_image_data_returns_validation_error(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            # type: ignore[arg-type] — testing runtime guard
+            result = write_photo(identifier="ABCD", image_data=123)  # type: ignore[arg-type]
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_connector._run_cn_authorization_status.assert_not_called()
+
+
+class TestWritePhotoAuthFlow:
+    def test_auth_denied_passthrough_skips_write(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "denied"
+            result = write_photo(identifier="ABCD", image_data=_JPEG_B64)
+        assert result["success"] is False
+        assert result["error_type"] == "authorization_denied"
+        mock_connector._run_cn_write_photo.assert_not_called()
+
+
+class TestWritePhotoTestModeSafety:
+    def test_test_mode_without_group_arg_blocked(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        _get_test_group_identifiers.cache_clear()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                result = write_photo(
+                    identifier="ABCD", image_data=_JPEG_B64
+                )
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        mock_connector._run_cn_write_photo.assert_not_called()
+
+
+class TestWritePhotoHappyPath:
+    def test_writes_decoded_bytes_to_connector(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_write_photo.return_value = "ABCD"
+            result = write_photo(identifier="ABCD", image_data=_JPEG_B64)
+        assert result == {"success": True, "identifier": "ABCD"}
+        kwargs = mock_connector._run_cn_write_photo.call_args.kwargs
+        assert kwargs["identifier"] == "ABCD"
+        assert kwargs["image_data"] == _JPEG_BYTES
+
+    def test_clear_passes_none_through(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_write_photo.return_value = "ABCD"
+            result = write_photo(identifier="ABCD", image_data=None)
+        assert result == {"success": True, "identifier": "ABCD"}
+        kwargs = mock_connector._run_cn_write_photo.call_args.kwargs
+        assert kwargs["image_data"] is None
+
+
+class TestWritePhotoErrors:
+    def test_not_found_from_connector(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_write_photo.side_effect = (
+                ContactsNotFoundError("Contact not found: 'BAD'")
+            )
+            result = write_photo(identifier="BAD", image_data=_JPEG_B64)
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+
+    def test_save_failure_returns_unknown(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_write_photo.side_effect = ContactsError(
+                "save boom"
+            )
+            result = write_photo(identifier="ABCD", image_data=_JPEG_B64)
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "save boom" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from apple_contacts_mcp.utils import (
+    detect_image_format,
     escape_applescript_string,
     label_to_apple_token,
 )
@@ -134,3 +135,60 @@ def test_label_empty_string_passes_through() -> None:
 def test_label_whitespace_only_passes_through() -> None:
     """Whitespace-only is not a valid human form; treat as custom (don't crash)."""
     assert label_to_apple_token("   ") == "   "
+
+
+# ---------------------------------------------------------------------------
+# detect_image_format
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("magic", "expected"),
+    [
+        # JPEG: FF D8 FF followed by anything (JFIF, EXIF, etc. all share the prefix)
+        (b"\xff\xd8\xff\xe0\x00\x10JFIF\x00", "jpeg"),
+        (b"\xff\xd8\xff\xe1\x00\x10Exif\x00", "jpeg"),
+        # PNG: full 8-byte signature
+        (b"\x89PNG\r\n\x1a\n" + b"\x00" * 16, "png"),
+        # GIF: 87a or 89a variants both start "GIF8"
+        (b"GIF87a" + b"\x00" * 10, "gif"),
+        (b"GIF89a" + b"\x00" * 10, "gif"),
+    ],
+)
+def test_detect_image_format_known_formats(magic: bytes, expected: str) -> None:
+    assert detect_image_format(magic) == expected
+
+
+@pytest.mark.parametrize(
+    "brand", [b"heic", b"heix", b"heif", b"hevc", b"hevx", b"mif1", b"msf1"]
+)
+def test_detect_image_format_heic_brands(brand: bytes) -> None:
+    """Apple emits several HEIF-family ftyp brands; all should detect as 'heic'."""
+    # 4-byte size prefix + 'ftyp' + brand + rest
+    data = b"\x00\x00\x00\x18ftyp" + brand + b"\x00" * 32
+    assert detect_image_format(data) == "heic"
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"",
+        b"\x00",
+        b"\x00\x00",
+        b"hello world",
+        b"\xff\xd8",  # truncated JPEG header (1 byte short)
+        b"\x89PN",  # truncated PNG header
+        b"\x00\x00\x00\x18ftypwhat" + b"\x00" * 16,  # ftyp with unknown brand
+        b"randombytesthatlooklikenothing",
+    ],
+)
+def test_detect_image_format_unknown_or_short_input(data: bytes) -> None:
+    assert detect_image_format(data) == "unknown"
+
+
+def test_detect_image_format_does_not_raise_on_short_input() -> None:
+    """The detector must be robust against any-length input.
+    Every byte length from 0..12 should return 'unknown' without raising."""
+    for n in range(13):
+        # Use bytes that don't match any magic
+        assert detect_image_format(b"\x01" * n) == "unknown"


### PR DESCRIPTION
## Summary

Adds the contact-photo surface. Two dedicated tools mirroring `read_note` / `write_note`, plus a pure-Python magic-byte detector for the read path's `format` field.

### New tools

| Tool | Connector primitive | Test-mode posture |
|---|---|---|
| `read_photo(identifier)` | `imageDataAvailable()` → `imageData()` (always guarded) | Read-only; no gating |
| `write_photo(identifier, image_data, group_identifier=None)` | fetch + `mutableCopy` + `setImageData_` + `updateContact_` | `check_test_mode_safety` (matches `update_contact`) |

### Response shapes

**`read_photo`** transports binary via base64 — JSON-safe over the MCP wire:

```jsonc
// Photo set
{"success": true, "identifier": "ABCD-…", "image_data": "<base64>",
 "format": "jpeg", "size_bytes": 12345}

// Contact exists, no photo set — SUCCESS, not not_found
{"success": true, "identifier": "ABCD-…", "image_data": null,
 "format": null, "size_bytes": 0}
```

The contact-exists-but-no-photo case is a success (callers check `image_data is not None`), distinct from `not_found` which means the identifier didn't match any contact.

**`write_photo`** accepts base64 input; `null` clears. Permissive on format — Apple is the authority on accepted bytes, so we don't pre-validate magic bytes. Bad bytes surface as `unknown` via CN's save error.

### `detect_image_format(bytes) -> str`

Pure-Python magic-byte detector returning one of `"jpeg"` / `"png"` / `"gif"` / `"heic"` / `"unknown"`. The `"heic"` bucket covers all HEIF-family ISOBMFF brands Apple actually emits (heic, heix, heif, hevc, hevx, mif1, msf1) — they're all "HEIF-flavored bytes" from a caller's perspective. Robust against short / empty input; never raises.

### Notable gotcha respected

Per [gap analysis §6 Q5](docs/research/contacts-api-gap-analysis.md#L297), `imageData()` on a photo-less contact misbehaves empirically. The connector always checks `imageDataAvailable()` first and returns `{available: False, image_data: b""}` without ever calling `imageData()`. Locked in by a unit test.

### Validation

- 471 unit tests pass (424 baseline + 47 new); coverage **97.98%**.
- `check_complexity.sh` ✓ — exits 0; no functions exceed CC=20.
- `check_client_server_parity.sh` ✓ — 21 tools wired; every connector method has a server tool.
- `check_version_sync.sh` ✓.

## Test plan

- [ ] CI green on the honest complexity gate.
- [ ] Manual smoke (`CONTACTS_TEST_MODE=true CONTACTS_TEST_GROUP=MCP-Test`):
  - `read_photo(<id>)` on a contact with no photo → `image_data: null`, `format: null`, `size_bytes: 0`.
  - Set a photo via Contacts.app (drag a JPEG), then `read_photo` → base64 bytes; `format == "jpeg"`; `size_bytes > 0`.
  - `write_photo(<id>, <small JPEG b64>, group_identifier="MCP-Test")` → Contacts.app reflects the new photo.
  - `write_photo(<id>, None, group_identifier="MCP-Test")` clears the photo.
  - `read_photo` on a missing contact → `not_found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)