### PR TITLE
release: v0.3.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,11 +1,15 @@
 # Apple Contacts MCP Server
 
-**Version:** v0.2.1
+**Version:** v0.3.0
 
-v0.2.1 is a patch release covering release-gate follow-ups from v0.2.0:
-fixes the `check_complexity.sh` script and refactors the validators it
-flagged, and aligns `create_contact`'s success response with `import_vcard`
-on `group_id` shape (always present, `null` when no group). See
+v0.3.0 ships the Phase 3 surface: containers (`list_containers` +
+`container_identifier` on `create_contact`), group CRUD (`create_group`,
+`rename_group`, `delete_group`), contact photo read/write with magic-byte
+format detection (`read_photo`, `write_photo`), and four niche labeled-value
+families (`dates`, `social_profiles`, `relations`, `instant_messages`) opt-in
+via `include_niche=True` on `get_contact`. Also closes gap-analysis Q8a
+(multi-container write round-trip empirically resolved) and lands the
+per-tool performance baselines suite. See
 [docs/reference/TOOLS.md](../docs/reference/TOOLS.md) for the API surface
 and [CHANGELOG.md](../CHANGELOG.md) for release notes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-12
+
+Phase 3 release. Six issues closed: container-aware tools (#26), photo read/write (#25), group CRUD (#24), niche fields (#27), per-tool performance baselines (#28), and the multi-container write round-trip research (#29). Plus a release-gate cleanup PR (#73) clearing pre-existing IDE lint/schema warnings. Tool count: 16 → **21**.
+
+### Fixed
+
+- `_run_cn_update_contact` now fetches the four P3 niche keys (`CNContactDatesKey`, `CNContactSocialProfilesKey`, `CNContactRelationsKey`, `CNContactInstantMessageAddressesKey`) so partial-field updates of any niche field don't trigger `CNPropertyNotFetchedException` at the setter. Caught in the v0.3.0 release-gate review. Locked in by a regression test that asserts the keysToFetch list contains all four.
+
+### Security
+
+- Bumped transitive dependency urllib3 2.6.3 → 2.7.0 (CVE-2026-44431, CVE-2026-44432). Pulled in via requests; no direct caller affected, but the release-gate dependency scan caught it.
+
 ### Added
 
 - `list_containers` — enumerate contact containers (accounts: iCloud, Gmail, Exchange, On-My-Mac). Returns `{id, name, type, is_default}` per entry, capped at 10. `type` is one of `"local"` / `"exchange"` / `"cardDAV"` (even iCloud reports as `cardDAV` — the sync protocol). `is_default` flags the container new contacts go into when `container_identifier` isn't specified (#26).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol server for Apple Contacts on macOS.
 
-**Version:** v0.2.1 — patch release covering release-gate follow-ups from v0.2.0 (complexity-script fix + `create_contact` / `import_vcard` `group_id` response shape alignment). The full v0.2.0 surface (field-scoped search, group read/write, note read/write, vCard import/export) ships unchanged. See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for the API surface and [CHANGELOG.md](CHANGELOG.md) for release notes.
+**Version:** v0.3.0 — Phase 3 surface: containers, group CRUD, contact photos, niche fields. 21 tools total. See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for the API surface and [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 ## Tools
 
@@ -12,7 +12,7 @@ A Model Context Protocol server for Apple Contacts on macOS.
 - `search_contacts` — predicate by name, phone, email, or organization.
 - `create_contact` — write via `CNSaveRequest`.
 - `update_contact` — partial-field update.
-- `delete_contact` — test-mode-only in v0.2.x; full destructive UX ships in v0.4.0.
+- `delete_contact` — test-mode-only until v0.4.0 ships the full destructive UX with confirmation prompts.
 - `read_note` / `write_note` — note field via AppleScript fallback (entitlement-gated in CN).
 - `read_photo` / `write_photo` — contact photo as base64-encoded bytes; read returns the detected format (JPEG/PNG/HEIC/GIF).
 - `list_groups` / `get_contacts_in_group` — group read.

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -2,7 +2,7 @@
 
 Reference for every MCP tool the apple-contacts-mcp server exposes.
 
-**Version:** v0.2.1 (tracks the package version)
+**Version:** v0.3.0 (tracks the package version)
 **Tools:** 21
 
 The source-of-truth for tool behavior is the docstrings in
@@ -299,7 +299,12 @@ def create_contact(
     urls: list[dict[str, str]] | None = None,
     postal_addresses: list[dict[str, str]] | None = None,
     birthday: dict[str, int] | None = None,
+    dates: list[dict[str, Any]] | None = None,
+    social_profiles: list[dict[str, str]] | None = None,
+    relations: list[dict[str, str]] | None = None,
+    instant_messages: list[dict[str, str]] | None = None,
     group_identifier: str | None = None,
+    container_identifier: str | None = None,
 ) -> dict[str, Any]
 ```
 
@@ -1008,7 +1013,7 @@ Common envelope:
 |---|---|---|
 | `validation_error` | Caller violated the input contract — bad type, bad shape, empty required field, out-of-range birthday, email without `@`, etc. | — |
 | `authorization_denied` | TCC blocked the operation. The LLM should call `check_authorization` to disambiguate (`notDetermined` / `denied` / `restricted`) and surface `remediation` to the user. | `status`, `remediation` |
-| `safety_violation` | The destructive-op gate refused: either `CONTACTS_TEST_MODE=true` was set without a matching `group_identifier`, or `delete_contact` was called outside test mode. | — |
+| `safety_violation` | The destructive-op gate refused: either `CONTACTS_TEST_MODE=true` was set without a matching `group_identifier`, or `delete_contact` / `delete_group` was called outside test mode. | — |
 | `not_found` | A referenced CN object (contact identifier or `group_identifier`) doesn't exist in the unified store. | — |
 | `unknown` | Anything else — usually a CN save failure or an unexpected PyObjC error. The `error` field has the underlying message. | — |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-contacts-mcp"
-version = "0.2.1"
+version = "0.3.0"
 description = "MCP server for Apple Contacts integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_contacts_mcp/__init__.py
+++ b/src/apple_contacts_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Contacts MCP Server.
 A Model Context Protocol server for Apple Contacts integration.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/src/apple_contacts_mcp/contacts_connector.py
+++ b/src/apple_contacts_mcp/contacts_connector.py
@@ -598,10 +598,12 @@ class ContactsConnector:
         """
         from Contacts import (
             CNContactBirthdayKey,
+            CNContactDatesKey,
             CNContactDepartmentNameKey,
             CNContactEmailAddressesKey,
             CNContactFamilyNameKey,
             CNContactGivenNameKey,
+            CNContactInstantMessageAddressesKey,
             CNContactJobTitleKey,
             CNContactMiddleNameKey,
             CNContactNamePrefixKey,
@@ -610,10 +612,16 @@ class ContactsConnector:
             CNContactOrganizationNameKey,
             CNContactPhoneNumbersKey,
             CNContactPostalAddressesKey,
+            CNContactRelationsKey,
+            CNContactSocialProfilesKey,
             CNContactUrlAddressesKey,
             CNSaveRequest,
         )
 
+        # Fetch the full P1 + P3 key set. CN raises CNPropertyNotFetchedException
+        # on any setter for a key that wasn't fetched, so an incomplete keys list
+        # would break partial updates of any niche field. The extra fetch cost is
+        # negligible vs. correctness.
         keys = [
             CNContactGivenNameKey,
             CNContactFamilyNameKey,
@@ -629,6 +637,10 @@ class ContactsConnector:
             CNContactPostalAddressesKey,
             CNContactUrlAddressesKey,
             CNContactBirthdayKey,
+            CNContactDatesKey,
+            CNContactSocialProfilesKey,
+            CNContactRelationsKey,
+            CNContactInstantMessageAddressesKey,
         ]
 
         store = self._get_store()

--- a/tests/unit/test_contacts_connector.py
+++ b/tests/unit/test_contacts_connector.py
@@ -1697,6 +1697,11 @@ def _install_fake_contacts_for_modify(
         "CNContactUrlAddressesKey",
         "CNContactBirthdayKey",
         "CNContactIdentifierKey",
+        # P3 niche keys — fetched unconditionally so update can set them.
+        "CNContactDatesKey",
+        "CNContactSocialProfilesKey",
+        "CNContactRelationsKey",
+        "CNContactInstantMessageAddressesKey",
     ):
         setattr(fake_contacts, k, k)
 
@@ -1902,6 +1907,33 @@ def test_update_contact_with_niche_fields(
     mutable.setSocialProfiles_.assert_called_once()
     mutable.setContactRelations_.assert_called_once()
     mutable.setInstantMessageAddresses_.assert_called_once()
+
+
+def test_update_contact_fetches_all_p1_and_p3_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: CN raises CNPropertyNotFetchedException on setters for
+    keys that weren't fetched. The update path must request P1 + P3 keys
+    unconditionally so any partial-field update works. Caught by the
+    v0.3.0 release-gate review."""
+    fetched = MagicMock(name="CNContact_fetched")
+    store, _, _, _ = _install_fake_contacts_for_modify(
+        monkeypatch, fetched_contact=fetched
+    )
+    connector = ContactsConnector()
+    connector._run_cn_update_contact("ABCD", {"given_name": "X"})
+    args, _ = store.unifiedContactWithIdentifier_keysToFetch_error_.call_args
+    fetched_keys = args[1]
+    # The four niche keys must be present alongside the P1 set.
+    for required in (
+        "CNContactDatesKey",
+        "CNContactSocialProfilesKey",
+        "CNContactRelationsKey",
+        "CNContactInstantMessageAddressesKey",
+    ):
+        assert required in fetched_keys, (
+            f"{required} missing from update_contact keysToFetch"
+        )
 
 
 def test_update_contact_niche_empty_list_clears(

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -12,7 +12,7 @@ from apple_contacts_mcp.security import sanitize_input
 
 
 def test_version() -> None:
-    assert __version__ == "0.2.1"
+    assert __version__ == "0.3.0"
 
 
 def test_connector_instantiates() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "apple-contacts-mcp"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -2196,11 +2196,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

v0.3.0 — Phase 3 release. Six closed issues plus a release-gate cleanup. Tool count: **16 → 21**.

### New tools and changes

| # | Feature | Tool surface |
|---|---|---|
| #26 | Container-aware tools | `list_containers`; `container_identifier` parameter on `create_contact` (non-breaking) |
| #25 | Contact photo r/w | `read_photo`, `write_photo`; new `detect_image_format` helper |
| #24 | Group CRUD | `create_group`, `rename_group`, `delete_group` (test-mode-only until #36) |
| #27 | Niche fields | `dates`, `social_profiles`, `relations`, `instant_messages` on get/create/update; `include_niche=True` opt-in on `get_contact` |
| #28 | Perf baselines | 14 benchmarks + committed `baseline.json` + filled-in `contacts-performance` skill |
| #29 | Multi-container research | Decision doc resolving gap-analysis Q8a |
| #73 | IDE-lint cleanup | Workflow `id`, dependabot `uv` ecosystem, SKILL.md fixes |

### Release-gate review fixes

The cumulative diff was reviewed; four issues caught and fixed before tagging:

- **Critical bug:** `_run_cn_update_contact` was missing the four P3 niche keys in its `keysToFetch` list. Partial updates of any niche field would crash with `CNPropertyNotFetchedException` at the setter. Fixed by fetching the full P1 + P3 key set; regression test added.
- **Doc drift:** `TOOLS.md` create_contact signature block stale (missing 5 v0.3.0 params) — updated.
- **README:** delete_contact note read "v0.2.x" — reworded to drop the version suffix.
- **TOOLS.md error-types appendix:** `safety_violation` mentioned only `delete_contact` — added `delete_group`.

### Security

Bumped transitive dep `urllib3` 2.6.3 → 2.7.0 (CVE-2026-44431, CVE-2026-44432). Pulled in via `requests`. The release-gate `check_dependencies.sh` caught it.

### Validation

- `check_version_sync.sh` ✓ — all four files at 0.3.0.
- `check_client_server_parity.sh` ✓ — 21 tools wired.
- `check_complexity.sh` ✓ — no functions over CC=20.
- `make test` ✓ — 487 unit tests pass; coverage **97.96%**.
- `check_dependencies.sh` ✓ — no known vulnerabilities (after urllib3 bump).

## Test plan

- [ ] CI green on the unit suite.
- [ ] Manual smoke (`CONTACTS_TEST_MODE=true CONTACTS_TEST_GROUP=MCP-Test`):
  - `update_contact(<id>, dates=[{...}])` — regression test confirms keysToFetch, but a real-CN smoke is worth one round-trip.
  - `list_containers()` returns at least one entry with `is_default: true`.
  - `create_group / rename_group / delete_group` round-trip cleanly.
  - `read_photo / write_photo` round-trip with a JPEG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)