### PR TITLE
fix: release workflow shell-injection on CHANGELOG content

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,18 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
+        # `--notes` content is passed through an env var so the shell never
+        # sees the CHANGELOG body inlined. Inlining via `${{ ... }}` lets
+        # any backticks, $(...), or bare words in the release notes execute
+        # as shell — caught in v0.3.0's release when the niche-field
+        # examples broke the workflow.
         run: |
           gh release create "$GITHUB_REF_NAME" \
             --title "Release $GITHUB_REF_NAME" \
-            --notes "${{ steps.changelog.outputs.notes }}"
+            --notes "$RELEASE_NOTES"
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_NOTES: ${{ steps.changelog.outputs.notes }}
 
       - name: Close milestone
         run: |


### PR DESCRIPTION
## Summary

The Create GitHub Release step in `release.yml` inlined the CHANGELOG body via `${{ steps.changelog.outputs.notes }}`, so anything in the release notes that looked shell-active executed verbatim. v0.3.0's CHANGELOG was the first one with enough code-like content (function names, `{label, ...}` examples, paths like `tests/benchmarks/`) to actually trip it.

The failure surfaced as a long string of `command not found` errors from the workflow runner trying to execute fragments of the release notes:

```
/bin/sh: line 1: jpeg: command not found
/bin/sh: line 1: get_contact: command not found
/bin/sh: line 1: {label,: command not found
/bin/sh: line 1: tests/benchmarks/: Is a directory
...
```

The release for v0.3.0 was created manually after the workflow failure; the milestone was closed manually too.

## Fix

Pass the notes via an env var (`RELEASE_NOTES`) instead. The shell only sees the variable reference; the content stays untouched. Same pattern recommended by GitHub Actions security guidance for any multiline output piped to a `run:` step.

```diff
       - name: Create GitHub Release
         run: |
           gh release create "$GITHUB_REF_NAME" \
             --title "Release $GITHUB_REF_NAME" \
-            --notes "${{ steps.changelog.outputs.notes }}"
+            --notes "$RELEASE_NOTES"
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_NOTES: ${{ steps.changelog.outputs.notes }}
```

## Test plan

- [ ] CI on this PR is green (the workflow itself only runs on tag push, so PR CI just runs the unit tests — they should pass since nothing else changed).
- [ ] Next tagged release will exercise the fix for real. If `v0.3.1` ships before this is forgotten, it should auto-succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)