### PR TITLE
feat: confirmation UX for delete_contact + delete_group (closes #36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `delete_contact` and `delete_group` are now `async` and accept the FastMCP `Context` so they can elicit confirmation from the user. Outside test mode they prompt with `Delete <kind> '<name>' (<id>)? This cannot be undone.` (Yes / No); inside test mode the existing test-group safety gate applies unchanged. The entity name is pre-fetched so the prompt isn't an opaque UUID; a missing identifier short-circuits to `not_found` without prompting. New `_confirm_destructive` helper in `security.py` centralizes the elicitation logic and the unsupported-client fallback (#36).
+
+### Added
+
+- `user_declined` error type for the two delete tools when the user declines or cancels the confirmation prompt. Documented in TOOLS.md's error-types appendix.
+
+### Removed
+
+- `require_test_mode_for` is no longer wired into any tool. The helper remains in `security.py` for forward-compatibility but the v0.1.0–v0.3.x posture of "destructive ops refuse outright outside test mode" has been replaced by the elicitation flow. Clients that don't support elicitation fall back to a clear `safety_violation` pointing at `CONTACTS_TEST_MODE` (#36).
+
 ## [0.3.0] - 2026-05-12
 
 Phase 3 release. Six issues closed: container-aware tools (#26), photo read/write (#25), group CRUD (#24), niche fields (#27), per-tool performance baselines (#28), and the multi-container write round-trip research (#29). Plus a release-gate cleanup PR (#73) clearing pre-existing IDE lint/schema warnings. Tool count: 16 → **21**.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ A Model Context Protocol server for Apple Contacts on macOS.
 - `search_contacts` — predicate by name, phone, email, or organization.
 - `create_contact` — write via `CNSaveRequest`.
 - `update_contact` — partial-field update.
-- `delete_contact` — test-mode-only until v0.4.0 ships the full destructive UX with confirmation prompts.
+- `delete_contact` — out-of-band confirmation via FastMCP elicitation outside test mode; refuses gracefully on clients without elicit support.
 - `read_note` / `write_note` — note field via AppleScript fallback (entitlement-gated in CN).
 - `read_photo` / `write_photo` — contact photo as base64-encoded bytes; read returns the detected format (JPEG/PNG/HEIC/GIF).
 - `list_groups` / `get_contacts_in_group` — group read.
 - `add_contact_to_group` / `remove_contact_from_group` — group membership.
-- `create_group` / `rename_group` / `delete_group` — group CRUD. `delete_group` is test-mode-only in v0.3.x; full destructive UX with confirmation prompts ships in v0.4.0.
+- `create_group` / `rename_group` / `delete_group` — group CRUD. `delete_group` uses the same elicitation-confirmation flow as `delete_contact`.
 - `export_vcard` / `import_vcard` — vCard 3.0 serialization round-trip.
 - `list_containers` — list accounts (iCloud, Gmail, Exchange, On-My-Mac). Pair with `create_contact(..., container_identifier=...)` to write to a non-default container.
 

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -440,7 +440,7 @@ Use `get_contact(identifier)` to read back the updated record.
 Delete an existing contact by identifier.
 
 ```python
-def delete_contact(
+async def delete_contact(
     identifier: str,
     group_identifier: str | None = None,
 ) -> dict[str, Any]
@@ -459,12 +459,16 @@ def delete_contact(
 {"success": true, "identifier": "ABCD-…"}
 ```
 
-**Error types:** `validation_error`, `safety_violation`, `authorization_denied`, `not_found`, `unknown`.
+**Error types:** `validation_error`, `safety_violation`, `user_declined`, `authorization_denied`, `not_found`, `unknown`.
 
 **Notes:**
-- **v0.1.0 only allows delete in test mode.** Outside `CONTACTS_TEST_MODE=true` this returns `error_type: "safety_violation"` — the full destructive UX (with confirmation prompts) ships in v0.4.0 (#24).
-- The `require_test_mode_for` gate fires **before** the auth check, so users outside test mode never see a TCC prompt for a call that's about to be refused.
-- In test mode, the existing test-group gate also enforces that `group_identifier` matches `CONTACTS_TEST_GROUP`.
+- **Outside test mode, the tool requires explicit user confirmation via FastMCP elicitation.** The client renders `Delete contact 'Alice Adams' (ABCD-…)? This cannot be undone.` with **Yes, delete** / **No, cancel** buttons. The contact's name is pre-fetched so the prompt isn't an opaque UUID.
+  - **Yes** → delete proceeds.
+  - **No / Declined / Cancelled** → `user_declined`.
+  - **Client doesn't support elicitation** → `safety_violation`, pointing at `CONTACTS_TEST_MODE` as the bypass.
+  - **Identifier doesn't match any contact** → `not_found` *before* prompting (no point asking the user about a non-existent record).
+- **In test mode** (`CONTACTS_TEST_MODE=true`), confirmation is skipped and the existing test-group safety gate applies: `group_identifier` must match `CONTACTS_TEST_GROUP`. This preserves the existing harness path.
+- Auth is checked before the test-mode branch, so users outside test mode in an unauthorized state still see the standard `authorization_denied` first.
 
 ---
 
@@ -969,7 +973,7 @@ def rename_group(
 Delete an existing contact group.
 
 ```python
-def delete_group(
+async def delete_group(
     identifier: str,
     group_identifier: str | None = None,
 ) -> dict[str, Any]
@@ -988,10 +992,10 @@ def delete_group(
 {"success": true, "identifier": "GRP-…:ABGroup"}
 ```
 
-**Error types:** `validation_error`, `authorization_denied`, `safety_violation`, `not_found`, `unknown`.
+**Error types:** `validation_error`, `safety_violation`, `user_declined`, `authorization_denied`, `not_found`, `unknown`.
 
 **Notes:**
-- **v0.3.0 only allows delete in test mode** — the full destructive UX (with confirmation prompts) ships in v0.4.0 (#36). Outside test mode this returns a `safety_violation`. Same posture as `delete_contact`.
+- **Outside test mode, requires explicit user confirmation via FastMCP elicitation** — same UX and error shape as `delete_contact`. The group's name is pre-fetched and shown in the prompt. `Yes` proceeds; `No` / `Declined` / `Cancelled` returns `user_declined`; client-without-elicit returns `safety_violation`.
 - **Member contacts are NOT deleted** — they remain in the address book; they just lose membership in the now-removed group.
 
 ---
@@ -1013,7 +1017,8 @@ Common envelope:
 |---|---|---|
 | `validation_error` | Caller violated the input contract — bad type, bad shape, empty required field, out-of-range birthday, email without `@`, etc. | — |
 | `authorization_denied` | TCC blocked the operation. The LLM should call `check_authorization` to disambiguate (`notDetermined` / `denied` / `restricted`) and surface `remediation` to the user. | `status`, `remediation` |
-| `safety_violation` | The destructive-op gate refused: either `CONTACTS_TEST_MODE=true` was set without a matching `group_identifier`, or `delete_contact` / `delete_group` was called outside test mode. | — |
+| `safety_violation` | The destructive-op gate refused: in test mode, the asserted `group_identifier` didn't match `CONTACTS_TEST_GROUP`; outside test mode for `delete_contact` / `delete_group`, the client doesn't support FastMCP elicitation (no way to confirm). | — |
+| `user_declined` | The user explicitly declined or cancelled an elicitation confirmation prompt (`delete_contact`, `delete_group`). The destructive op was not performed. | — |
 | `not_found` | A referenced CN object (contact identifier or `group_identifier`) doesn't exist in the unified store. | — |
 | `unknown` | Anything else — usually a CN save failure or an unexpected PyObjC error. The `error` field has the underlying message. | — |
 

--- a/src/apple_contacts_mcp/security.py
+++ b/src/apple_contacts_mcp/security.py
@@ -11,8 +11,12 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+from collections.abc import Awaitable, Callable
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from fastmcp.server.context import Context
 
 logger = logging.getLogger(__name__)
 
@@ -185,4 +189,113 @@ def _safety_error(operation: str, message: str) -> dict[str, Any]:
         "success": False,
         "error": message,
         "error_type": "safety_violation",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Destructive-op confirmation UX (FastMCP elicitation)
+# ---------------------------------------------------------------------------
+
+# The two yes/no choices presented to the user. The exact strings are part
+# of the protocol — `_confirm_destructive` matches on `_CONFIRM_YES` to
+# decide whether to proceed.
+_CONFIRM_YES = "Yes, delete"
+_CONFIRM_NO = "No, cancel"
+
+
+async def _confirm_destructive(
+    ctx: Context,
+    *,
+    operation: str,
+    entity_kind: str,
+    identifier: str,
+    preview_lookup: Callable[[], dict[str, Any] | None]
+    | Callable[[], Awaitable[dict[str, Any] | None]],
+    describe: Callable[[dict[str, Any]], str],
+) -> dict[str, Any] | None:
+    """Confirm a destructive op via FastMCP elicitation. Returns None when
+    the user confirmed; an error dict otherwise.
+
+    Flow:
+      1. Pre-fetch the target entity via ``preview_lookup`` so the prompt
+         shows a human-readable preview. Lookup returning ``None`` short-
+         circuits to a ``not_found`` response without prompting.
+      2. Call ``ctx.elicit()`` with a two-option choice. The accepted result
+         must be ``_CONFIRM_YES`` to proceed; anything else (including
+         declined / cancelled) returns ``user_declined``.
+      3. If the client doesn't support elicitation, ``ctx.elicit()`` raises.
+         Catch broadly and return ``safety_violation`` pointing at test mode
+         as the bypass — same posture as the v0.1.0+ test-mode gate.
+    """
+    from fastmcp.server.elicitation import (
+        AcceptedElicitation,
+        CancelledElicitation,
+        DeclinedElicitation,
+    )
+
+    try:
+        preview = preview_lookup()
+    except Exception as exc:
+        logger.error("%s confirmation preview failed: %s", operation, exc)
+        return {
+            "success": False,
+            "error": f"{operation} preview failed: {exc}",
+            "error_type": "unknown",
+        }
+    if preview is None:
+        return {
+            "success": False,
+            "error": f"{entity_kind.capitalize()} not found: {identifier!r}",
+            "error_type": "not_found",
+        }
+
+    description = describe(preview)
+    prompt = (
+        f"Delete {entity_kind} {description!r} ({identifier})? "
+        f"This cannot be undone."
+    )
+
+    try:
+        result = await ctx.elicit(
+            prompt,
+            response_type=[_CONFIRM_YES, _CONFIRM_NO],
+            response_title=f"Confirm {operation}",
+        )
+    except Exception as exc:
+        logger.warning(
+            "%s elicitation failed (client may not support elicit): %s",
+            operation,
+            exc,
+        )
+        return _safety_error(
+            operation,
+            f"{operation} requires user confirmation, but the client doesn't "
+            f"support interactive prompts. Set CONTACTS_TEST_MODE=true with "
+            f"CONTACTS_TEST_GROUP and supply group_identifier to bypass for "
+            f"test-harness use.",
+        )
+
+    if isinstance(result, AcceptedElicitation) and result.data == _CONFIRM_YES:
+        return None
+
+    if isinstance(result, (DeclinedElicitation, CancelledElicitation)):
+        action = "declined" if isinstance(result, DeclinedElicitation) else "cancelled"
+    else:
+        # Accepted but with "No, cancel" (or any other value)
+        action = "cancelled"
+
+    logger.info(
+        "%s %s by user (identifier=%s, preview=%s)",
+        operation,
+        action,
+        identifier,
+        description,
+    )
+    return {
+        "success": False,
+        "error": (
+            f"User {action} the {operation} of {entity_kind} "
+            f"{description!r} ({identifier})."
+        ),
+        "error_type": "user_declined",
     }

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -9,9 +9,15 @@ from typing import Any, cast
 
 from fastmcp import FastMCP
 
+from fastmcp.server.context import Context
+
 from .contacts_connector import ContactsConnector, SearchField
 from .exceptions import ContactsError, ContactsNotFoundError, ContactsTimeoutError
-from .security import check_test_mode_safety, require_test_mode_for
+from .security import (
+    _confirm_destructive,
+    _is_test_mode_enabled,
+    check_test_mode_safety,
+)
 from .utils import detect_image_format
 
 logging.basicConfig(
@@ -928,19 +934,25 @@ def update_contact(
 
 
 @mcp.tool()
-def delete_contact(
+async def delete_contact(
+    ctx: Context,
     identifier: str,
     group_identifier: str | None = None,
 ) -> dict[str, Any]:
     """Delete an existing contact by identifier.
 
-    **v0.1.0+ only allows delete in test mode** — the full destructive
-    UX (with confirmation prompts) ships in v0.4.0 (#36). Outside test
-    mode this returns a safety_violation error.
+    Outside test mode, this tool requires explicit user confirmation via
+    FastMCP elicitation: the client renders "Delete contact 'X' (id)?
+    This cannot be undone." with Yes/No buttons before the delete runs.
+    Declined or cancelled prompts return ``user_declined``.
 
-    In test mode (``CONTACTS_TEST_MODE=true``), ``group_identifier``
-    must match ``CONTACTS_TEST_GROUP`` to ensure the deleted contact
-    is one the test harness created.
+    If the client doesn't support elicitation, the tool refuses with
+    ``safety_violation`` pointing at ``CONTACTS_TEST_MODE`` as the bypass
+    for test-harness use.
+
+    In test mode (``CONTACTS_TEST_MODE=true``), confirmation is skipped
+    and the existing test-group safety gate applies: ``group_identifier``
+    must match ``CONTACTS_TEST_GROUP``.
 
     Args:
         identifier: The contact's CN identifier.
@@ -951,30 +963,41 @@ def delete_contact(
         On success: ``{"success": True, "identifier": identifier}``.
         On bad input: ``{"success": False, "error_type":
         "validation_error", ...}``.
-        On test mode off: ``{"success": False, "error_type":
-        "safety_violation", ...}``.
+        On test-mode safety gate refusal or elicit-unsupported client:
+        ``safety_violation``.
+        On user declining the confirmation: ``user_declined``.
         On TCC denial: same shape as ``list_contacts``.
-        On contact not found: ``{"success": False, "error_type":
-        "not_found", ...}``.
-        On CN save failure: ``{"success": False, "error_type":
-        "unknown", ...}``.
+        On contact not found: ``not_found``.
+        On CN save failure: ``unknown``.
     """
     if not identifier or not identifier.strip():
         return _validation_error("identifier must be a non-empty string")
-
-    require_err = require_test_mode_for("delete_contact")
-    if require_err is not None:
-        return require_err
 
     auth_err = _require_contacts_authorization()
     if auth_err is not None:
         return auth_err
 
-    safety_err = check_test_mode_safety(
-        "delete_contact", group=group_identifier
-    )
-    if safety_err is not None:
-        return safety_err
+    if _is_test_mode_enabled():
+        safety_err = check_test_mode_safety(
+            "delete_contact", group=group_identifier
+        )
+        if safety_err is not None:
+            return safety_err
+    else:
+        confirm_err = await _confirm_destructive(
+            ctx,
+            operation="delete_contact",
+            entity_kind="contact",
+            identifier=identifier,
+            preview_lookup=lambda: connector._run_cn_unified_contact(identifier),
+            describe=lambda c: (
+                f"{c.get('given_name', '')} {c.get('family_name', '')}".strip()
+                or c.get("organization")
+                or "(no name)"
+            ),
+        )
+        if confirm_err is not None:
+            return confirm_err
 
     try:
         connector._run_cn_delete_contact(identifier=identifier)
@@ -1678,19 +1701,24 @@ def rename_group(
 
 
 @mcp.tool()
-def delete_group(
+async def delete_group(
+    ctx: Context,
     identifier: str,
     group_identifier: str | None = None,
 ) -> dict[str, Any]:
     """Delete an existing contact group.
 
-    **v0.3.0 only allows delete in test mode** — the full destructive
-    UX (with confirmation prompts) ships in v0.4.0 (#36). Outside test
-    mode this returns a safety_violation error.
-
-    In test mode (``CONTACTS_TEST_MODE=true``), ``group_identifier``
-    must equal ``CONTACTS_TEST_GROUP``. Same posture as
+    Outside test mode, this tool requires explicit user confirmation
+    via FastMCP elicitation: "Delete group 'X' (id)? This cannot be
+    undone." with Yes/No buttons before the delete runs. Same UX as
     ``delete_contact``.
+
+    If the client doesn't support elicitation, the tool refuses with
+    ``safety_violation`` pointing at ``CONTACTS_TEST_MODE`` as the
+    bypass for test-harness use.
+
+    In test mode (``CONTACTS_TEST_MODE=true``), confirmation is skipped
+    and ``group_identifier`` must equal ``CONTACTS_TEST_GROUP``.
 
     Member contacts are NOT deleted by this operation — they keep
     existing in the address book; they just lose membership in the
@@ -1704,7 +1732,9 @@ def delete_group(
     Returns:
         On success: ``{"success": True, "identifier": identifier}``.
         On bad input: ``validation_error``.
-        On test mode off: ``safety_violation``.
+        On test-mode safety gate refusal or elicit-unsupported client:
+        ``safety_violation``.
+        On user declining the confirmation: ``user_declined``.
         On TCC denial: ``authorization_denied``.
         On unknown ``identifier``: ``not_found``.
         On CN save failure: ``unknown``.
@@ -1712,19 +1742,27 @@ def delete_group(
     if not identifier or not identifier.strip():
         return _validation_error("identifier must be a non-empty string")
 
-    require_err = require_test_mode_for("delete_group")
-    if require_err is not None:
-        return require_err
-
     auth_err = _require_contacts_authorization()
     if auth_err is not None:
         return auth_err
 
-    safety_err = check_test_mode_safety(
-        "delete_group", group=group_identifier
-    )
-    if safety_err is not None:
-        return safety_err
+    if _is_test_mode_enabled():
+        safety_err = check_test_mode_safety(
+            "delete_group", group=group_identifier
+        )
+        if safety_err is not None:
+            return safety_err
+    else:
+        confirm_err = await _confirm_destructive(
+            ctx,
+            operation="delete_group",
+            entity_kind="group",
+            identifier=identifier,
+            preview_lookup=lambda: connector._run_cn_fetch_group(identifier),
+            describe=lambda g: str(g.name()),
+        )
+        if confirm_err is not None:
+            return confirm_err
 
     try:
         connector._run_cn_delete_group(identifier=identifier)

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -8,7 +8,6 @@ import logging
 from typing import Any, cast
 
 from fastmcp import FastMCP
-
 from fastmcp.server.context import Context
 
 from .contacts_connector import ContactsConnector, SearchField

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1052,71 +1052,195 @@ class TestUpdateContactErrors:
 # ---------------------------------------------------------------------------
 
 
+def _make_ctx_accept(value: str = "Yes, delete") -> MagicMock:
+    """Build a fake Context whose elicit() returns AcceptedElicitation(value)."""
+    from fastmcp.server.elicitation import AcceptedElicitation
+
+    ctx = MagicMock(name="Context(accept)")
+    ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data=value))
+    return ctx
+
+
+def _make_ctx_declined() -> MagicMock:
+    from fastmcp.server.elicitation import DeclinedElicitation
+
+    ctx = MagicMock(name="Context(declined)")
+    ctx.elicit = AsyncMock(return_value=DeclinedElicitation())
+    return ctx
+
+
+def _make_ctx_cancelled() -> MagicMock:
+    from fastmcp.server.elicitation import CancelledElicitation
+
+    ctx = MagicMock(name="Context(cancelled)")
+    ctx.elicit = AsyncMock(return_value=CancelledElicitation())
+    return ctx
+
+
+def _make_ctx_unsupported() -> MagicMock:
+    """Mock ctx whose elicit raises — simulates a client without elicit support."""
+    ctx = MagicMock(name="Context(unsupported)")
+    ctx.elicit = AsyncMock(
+        side_effect=RuntimeError("client does not support elicitation")
+    )
+    return ctx
+
+
+def _fake_contact_for_preview(
+    given: str = "Alice", family: str = "Adams"
+) -> dict[str, Any]:
+    """Minimal contact dict shaped like _run_cn_unified_contact's return."""
+    return {
+        "id": "ABCD",
+        "given_name": given,
+        "family_name": family,
+        "organization": "",
+    }
+
+
 class TestDeleteContactValidation:
-    def test_empty_identifier_returns_validation_error(self) -> None:
+    async def test_empty_identifier_returns_validation_error(self) -> None:
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            result = delete_contact(identifier="")
+            result = await delete_contact(MagicMock(), identifier="")
         assert result["success"] is False
         assert result["error_type"] == "validation_error"
         mock_connector._run_cn_authorization_status.assert_not_called()
 
 
-class TestDeleteContactRequiresTestMode:
-    def test_test_mode_off_returns_safety_violation(
+class TestDeleteContactTestModePath:
+    """In test mode, the existing group-scope safety gate applies and
+    no elicitation happens."""
+
+    async def test_no_group_arg_returns_safety_violation(
         self, monkeypatch: Any
     ) -> None:
-        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
-        with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            result = delete_contact(identifier="ABCD")
-        assert result["success"] is False
-        assert result["error_type"] == "safety_violation"
-        assert "CONTACTS_TEST_MODE" in result["error"]
-        # Auth was NOT triggered (no TCC prompt for an op we refused).
-        mock_connector._run_cn_authorization_status.assert_not_called()
-        mock_connector._run_cn_delete_contact.assert_not_called()
-
-    def test_test_mode_explicit_false_returns_safety_violation(
-        self, monkeypatch: Any
-    ) -> None:
-        monkeypatch.setenv("CONTACTS_TEST_MODE", "false")
-        with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            result = delete_contact(identifier="ABCD")
-        assert result["success"] is False
-        assert result["error_type"] == "safety_violation"
-        mock_connector._run_cn_authorization_status.assert_not_called()
-
-
-class TestDeleteContactTestGroupGate:
-    def test_test_mode_on_no_group_arg_blocked(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
         monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
         _get_test_group_identifiers.cache_clear()
+        ctx = MagicMock()
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
             mock_connector._run_cn_authorization_status.return_value = "authorized"
             with patch("subprocess.run", side_effect=FileNotFoundError):
-                result = delete_contact(identifier="ABCD")
+                result = await delete_contact(ctx, identifier="ABCD")
         assert result["success"] is False
         assert result["error_type"] == "safety_violation"
         mock_connector._run_cn_delete_contact.assert_not_called()
+        ctx.elicit.assert_not_called()
 
-    def test_test_mode_on_with_matching_group_proceeds(
+    async def test_matching_group_proceeds_without_elicit(
         self, monkeypatch: Any
     ) -> None:
         monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
         monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
         _get_test_group_identifiers.cache_clear()
+        ctx = MagicMock()
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
             mock_connector._run_cn_authorization_status.return_value = "authorized"
             mock_connector._run_cn_delete_contact.return_value = "ABCD"
             with patch("subprocess.run", side_effect=FileNotFoundError):
-                result = delete_contact(
-                    identifier="ABCD", group_identifier="MCP-Test"
+                result = await delete_contact(
+                    ctx, identifier="ABCD", group_identifier="MCP-Test"
                 )
         assert result == {"success": True, "identifier": "ABCD"}
+        ctx.elicit.assert_not_called()
+
+
+class TestDeleteContactConfirmation:
+    """Outside test mode, the user must confirm via elicitation."""
+
+    async def test_accept_yes_proceeds_with_delete(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        ctx = _make_ctx_accept("Yes, delete")
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_unified_contact.return_value = (
+                _fake_contact_for_preview()
+            )
+            mock_connector._run_cn_delete_contact.return_value = "ABCD"
+            result = await delete_contact(ctx, identifier="ABCD")
+        assert result == {"success": True, "identifier": "ABCD"}
+        ctx.elicit.assert_awaited_once()
+        mock_connector._run_cn_delete_contact.assert_called_once_with(
+            identifier="ABCD"
+        )
+
+    async def test_accept_no_returns_user_declined(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        ctx = _make_ctx_accept("No, cancel")
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_unified_contact.return_value = (
+                _fake_contact_for_preview()
+            )
+            result = await delete_contact(ctx, identifier="ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "user_declined"
+        mock_connector._run_cn_delete_contact.assert_not_called()
+
+    async def test_declined_returns_user_declined(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        ctx = _make_ctx_declined()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_unified_contact.return_value = (
+                _fake_contact_for_preview()
+            )
+            result = await delete_contact(ctx, identifier="ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "user_declined"
+        mock_connector._run_cn_delete_contact.assert_not_called()
+
+    async def test_cancelled_returns_user_declined(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        ctx = _make_ctx_cancelled()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_unified_contact.return_value = (
+                _fake_contact_for_preview()
+            )
+            result = await delete_contact(ctx, identifier="ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "user_declined"
+        mock_connector._run_cn_delete_contact.assert_not_called()
+
+    async def test_elicit_unsupported_returns_safety_violation(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        ctx = _make_ctx_unsupported()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_unified_contact.return_value = (
+                _fake_contact_for_preview()
+            )
+            result = await delete_contact(ctx, identifier="ABCD")
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        assert "CONTACTS_TEST_MODE" in result["error"]
+        mock_connector._run_cn_delete_contact.assert_not_called()
+
+    async def test_missing_contact_returns_not_found_without_prompting(
+        self, monkeypatch: Any
+    ) -> None:
+        """Pre-fetch returns None → not_found, elicit never called."""
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        ctx = _make_ctx_accept()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_unified_contact.return_value = None
+            result = await delete_contact(ctx, identifier="MISSING")
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+        ctx.elicit.assert_not_called()
+        mock_connector._run_cn_delete_contact.assert_not_called()
 
 
 class TestDeleteContactErrors:
-    def test_not_found_from_connector(self, monkeypatch: Any) -> None:
+    async def test_not_found_from_connector(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
         monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
         _get_test_group_identifiers.cache_clear()
@@ -1126,13 +1250,13 @@ class TestDeleteContactErrors:
                 ContactsNotFoundError("Contact not found: 'BAD'")
             )
             with patch("subprocess.run", side_effect=FileNotFoundError):
-                result = delete_contact(
-                    identifier="BAD", group_identifier="MCP-Test"
+                result = await delete_contact(
+                    MagicMock(), identifier="BAD", group_identifier="MCP-Test"
                 )
         assert result["success"] is False
         assert result["error_type"] == "not_found"
 
-    def test_save_failure_returns_unknown(self, monkeypatch: Any) -> None:
+    async def test_save_failure_returns_unknown(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
         monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
         _get_test_group_identifiers.cache_clear()
@@ -1142,8 +1266,8 @@ class TestDeleteContactErrors:
                 "delete boom"
             )
             with patch("subprocess.run", side_effect=FileNotFoundError):
-                result = delete_contact(
-                    identifier="ABCD", group_identifier="MCP-Test"
+                result = await delete_contact(
+                    MagicMock(), identifier="ABCD", group_identifier="MCP-Test"
                 )
         assert result["success"] is False
         assert result["error_type"] == "unknown"
@@ -2500,60 +2624,113 @@ class TestRenameGroupErrors:
 
 
 class TestDeleteGroupValidation:
-    def test_empty_identifier_returns_validation_error(self) -> None:
+    async def test_empty_identifier_returns_validation_error(self) -> None:
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            result = delete_group(identifier="")
+            result = await delete_group(MagicMock(), identifier="")
         assert result["success"] is False
         assert result["error_type"] == "validation_error"
         mock_connector._run_cn_authorization_status.assert_not_called()
 
 
-class TestDeleteGroupRequiresTestMode:
-    def test_test_mode_off_returns_safety_violation(
+class TestDeleteGroupTestModePath:
+    async def test_no_group_arg_returns_safety_violation(
         self, monkeypatch: Any
     ) -> None:
-        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
-        with patch("apple_contacts_mcp.server.connector") as mock_connector:
-            result = delete_group(identifier="GRP-1")
-        assert result["success"] is False
-        assert result["error_type"] == "safety_violation"
-        assert "CONTACTS_TEST_MODE" in result["error"]
-        # Auth was NOT triggered (no TCC prompt for an op we refused).
-        mock_connector._run_cn_authorization_status.assert_not_called()
-        mock_connector._run_cn_delete_group.assert_not_called()
-
-
-class TestDeleteGroupTestGroupGate:
-    def test_test_mode_on_no_group_arg_blocked(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
         monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
         _get_test_group_identifiers.cache_clear()
+        ctx = MagicMock()
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
             mock_connector._run_cn_authorization_status.return_value = "authorized"
             with patch("subprocess.run", side_effect=FileNotFoundError):
-                result = delete_group(identifier="GRP-1")
+                result = await delete_group(ctx, identifier="GRP-1")
         assert result["success"] is False
         assert result["error_type"] == "safety_violation"
         mock_connector._run_cn_delete_group.assert_not_called()
+        ctx.elicit.assert_not_called()
 
-    def test_test_mode_on_with_matching_group_proceeds(
+    async def test_matching_group_proceeds_without_elicit(
         self, monkeypatch: Any
     ) -> None:
         monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
         monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
         _get_test_group_identifiers.cache_clear()
+        ctx = MagicMock()
         with patch("apple_contacts_mcp.server.connector") as mock_connector:
             mock_connector._run_cn_authorization_status.return_value = "authorized"
             mock_connector._run_cn_delete_group.return_value = "GRP-1"
             with patch("subprocess.run", side_effect=FileNotFoundError):
-                result = delete_group(
-                    identifier="GRP-1", group_identifier="MCP-Test"
+                result = await delete_group(
+                    ctx, identifier="GRP-1", group_identifier="MCP-Test"
                 )
         assert result == {"success": True, "identifier": "GRP-1"}
+        ctx.elicit.assert_not_called()
+
+
+class TestDeleteGroupConfirmation:
+    """Outside test mode, the user must confirm via elicitation."""
+
+    async def test_accept_yes_proceeds_with_delete(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        ctx = _make_ctx_accept("Yes, delete")
+        fake_group = MagicMock()
+        fake_group.name.return_value = "Family"
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_fetch_group.return_value = fake_group
+            mock_connector._run_cn_delete_group.return_value = "GRP-1"
+            result = await delete_group(ctx, identifier="GRP-1")
+        assert result == {"success": True, "identifier": "GRP-1"}
+        ctx.elicit.assert_awaited_once()
+        mock_connector._run_cn_delete_group.assert_called_once_with(
+            identifier="GRP-1"
+        )
+
+    async def test_declined_returns_user_declined(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        ctx = _make_ctx_declined()
+        fake_group = MagicMock()
+        fake_group.name.return_value = "Family"
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_fetch_group.return_value = fake_group
+            result = await delete_group(ctx, identifier="GRP-1")
+        assert result["success"] is False
+        assert result["error_type"] == "user_declined"
+        mock_connector._run_cn_delete_group.assert_not_called()
+
+    async def test_elicit_unsupported_returns_safety_violation(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        ctx = _make_ctx_unsupported()
+        fake_group = MagicMock()
+        fake_group.name.return_value = "Family"
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_fetch_group.return_value = fake_group
+            result = await delete_group(ctx, identifier="GRP-1")
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+        assert "CONTACTS_TEST_MODE" in result["error"]
+        mock_connector._run_cn_delete_group.assert_not_called()
+
+    async def test_missing_group_returns_not_found_without_prompting(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        ctx = _make_ctx_accept()
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_fetch_group.return_value = None
+            result = await delete_group(ctx, identifier="MISSING")
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+        ctx.elicit.assert_not_called()
 
 
 class TestDeleteGroupErrors:
-    def test_not_found_from_connector(self, monkeypatch: Any) -> None:
+    async def test_not_found_from_connector(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
         monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
         _get_test_group_identifiers.cache_clear()
@@ -2563,13 +2740,13 @@ class TestDeleteGroupErrors:
                 ContactsNotFoundError("Group not found: 'BAD'")
             )
             with patch("subprocess.run", side_effect=FileNotFoundError):
-                result = delete_group(
-                    identifier="BAD", group_identifier="MCP-Test"
+                result = await delete_group(
+                    MagicMock(), identifier="BAD", group_identifier="MCP-Test"
                 )
         assert result["success"] is False
         assert result["error_type"] == "not_found"
 
-    def test_save_failure_returns_unknown(self, monkeypatch: Any) -> None:
+    async def test_save_failure_returns_unknown(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
         monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
         _get_test_group_identifiers.cache_clear()
@@ -2579,8 +2756,8 @@ class TestDeleteGroupErrors:
                 "save boom"
             )
             with patch("subprocess.run", side_effect=FileNotFoundError):
-                result = delete_group(
-                    identifier="GRP-1", group_identifier="MCP-Test"
+                result = await delete_group(
+                    MagicMock(), identifier="GRP-1", group_identifier="MCP-Test"
                 )
         assert result["success"] is False
         assert result["error_type"] == "unknown"


### PR DESCRIPTION
## Summary

Replaces the v0.1.0–v0.3.x posture of *destructive ops refuse outright outside test mode* with a real out-of-band confirmation flow via **FastMCP elicitation**. `delete_contact` and `delete_group` are now `async` and accept `ctx: Context`.

The v0.1.0+ docstrings have been pointing at this v0.4.0 issue (#36) for "the full destructive UX with confirmation prompts." Shipping it now.

### Flow

**Outside test mode:**

1. Pre-fetch the target entity (contact name or group name) so the prompt isn't an opaque UUID.
2. Missing identifier → `not_found` *before* prompting.
3. `ctx.elicit(message, [\"Yes, delete\", \"No, cancel\"])`.
4. Outcome:
   - Accepted **Yes** → proceed with the delete.
   - Accepted **No** / Declined / Cancelled → **`user_declined`** (new error type).
   - `elicit()` raises (client doesn't support elicitation) → **`safety_violation`** pointing at `CONTACTS_TEST_MODE` as the bypass.

**Inside test mode:** the existing `check_test_mode_safety` gate runs unchanged. No prompting, no behavior change for the integration-test harness.

### New `_confirm_destructive` helper

In `security.py`. Centralizes elicit logic, `user_declined` error shape, and the unsupported-client fallback. Both delete tools call it; future destructive ops (e.g., batch deletes) would just pass their own `preview_lookup` and `describe` callbacks.

### Other changes

- `require_test_mode_for` is no longer used in `server.py`. The helper stays in `security.py` for forward-compat, but the two call sites in `delete_contact` / `delete_group` are gone.
- New `error_type: user_declined`. Documented in TOOLS.md's error-types appendix.
- Docstrings on both tools rewritten to describe the new elicit-or-test-mode branching.

### Validation

- 494 unit tests pass (487 baseline + 7 new for the confirmation paths).
- `make coverage` → **97.66%**.
- `check_complexity.sh` ✓ — `delete_contact` lands at CC=11, well under the threshold.
- `check_client_server_parity.sh` ✓ — 21 tools wired.

## Test plan

- [ ] CI green on the unit suite.
- [ ] Manual smoke with Claude Desktop (or any elicit-capable client):
  - `CONTACTS_TEST_MODE=true CONTACTS_TEST_GROUP=MCP-Test`, `delete_contact(<tmp_id>, group_identifier=\"MCP-Test\")` → no prompt, just succeeds.
  - `CONTACTS_TEST_MODE` unset, `delete_contact(<id>)` → client shows prompt with the contact's name. Yes → success. No → `user_declined`.
  - Same for `delete_group`.
  - `CONTACTS_TEST_MODE` unset on a client without elicit support → `safety_violation` with test-mode hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)