### PR TITLE
feat: wire OperationLogger audit trail into all 21 tools (closes #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `OperationLogger` audit log in `security.py` — append-only in-memory record of every `@mcp.tool()` invocation with `{timestamp, operation, parameters, result}` shape. Four `result` values: `"success"` (logged by the tool body before the success return), `"rate_limited"` (by `check_rate_limit` on deny), `"safety_violation"` (by `_safety_error`, covering both `check_test_mode_safety` and `require_test_mode_for`, plus the elicit-unsupported branch of `_confirm_destructive`), and `"cancelled"` (by `_confirm_destructive` when the user declines, cancels, or explicitly answers "No"). Module singleton `operation_logger`; `get_recent_operations(limit=10)` returns the last N entries (#47).
+
 ### Changed
 
+- All 21 `@mcp.tool()` entries now call `operation_logger.log_operation(<name>, <curated-params>, "success")` immediately before each success return. Logged parameters are curated to exclude PII and content: identifiers, container/group IDs, counts (phone/email/url/postal/date/social/relation/im), lengths (note bytes, vcard bytes, image bytes, name lengths), booleans (`has_birthday`, `has_photo`, `clearing`), and sorted field-name lists for partial updates. Actual name/email/phone/URL/note/image content is NEVER persisted to the audit log. `read_photo` logs at two distinct sites (one per success branch — has-photo vs. no-photo). The three security primitives (`check_rate_limit`, `_safety_error`, `_confirm_destructive`) emit denied/cancelled entries themselves — tool bodies stay single-purpose. New drift-guard test `test_every_tool_calls_log_operation_with_own_name` mirrors #46's rate-limit guard and fails CI if a new tool ships without an audit-log call (#47).
+- `check_rate_limit` now consumes its `params` argument on deny: the call is appended to `operation_logger` with `result="rate_limited"`. The forward-compat docstring from #35 is removed. Tool-body callers pass no params today; the empty dict shapes the audit entry consistently (#47).
+- `_safety_error` gained an optional `params` kwarg defaulting to `{"violation": <message>}` so safety-gate denies land an audit entry with a clear payload even when the caller doesn't thread its own params (#47).
 - All 21 `@mcp.tool()` entries now call `check_rate_limit(<operation>)` after input validation and before the auth gate. The rate-limit primitive shipped in #35 is now actually enforced. Tools that exceed their tier's sliding window return `error_type: rate_limited` without triggering a TCC prompt or touching the connector. New drift-guard test `test_every_tool_calls_check_rate_limit_with_own_name` walks the server.py source and fails CI if a new tool ships without the gate (#46).
 
 ### Added

--- a/src/apple_contacts_mcp/security.py
+++ b/src/apple_contacts_mcp/security.py
@@ -14,6 +14,7 @@ import subprocess
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable
+from datetime import datetime
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
@@ -175,9 +176,71 @@ def require_test_mode_for(operation: str) -> dict[str, Any] | None:
     return None
 
 
-def _safety_error(operation: str, message: str) -> dict[str, Any]:
-    """Build the standard safety-violation error dict."""
+# ---------------------------------------------------------------------------
+# Operation audit log (#47)
+#
+# Append-only in-memory record of every tool invocation. Mirrors
+# `apple-mail-mcp/security.py::OperationLogger`. The contacts version curates
+# parameters at the call site — never log name/email/phone/URL/note content
+# or photo bytes; only identifiers, counts, lengths, and field-name lists.
+#
+# Tool bodies emit "success" entries on the happy path. The three security
+# primitives (`check_rate_limit`, `_safety_error`, `_confirm_destructive`)
+# emit their own deny entries so tool bodies stay single-purpose.
+# ---------------------------------------------------------------------------
+
+
+class OperationLogger:
+    """Append-only audit log of tool invocations.
+
+    `result` is one of: "success", "rate_limited", "safety_violation",
+    "cancelled". Denied results are emitted by the security primitive that
+    rejected the call; tool bodies only emit "success".
+    """
+
+    def __init__(self) -> None:
+        self.operations: list[dict[str, Any]] = []
+
+    def log_operation(
+        self,
+        operation: str,
+        parameters: dict[str, Any],
+        result: str = "success",
+    ) -> None:
+        self.operations.append(
+            {
+                "timestamp": datetime.now().isoformat(),
+                "operation": operation,
+                "parameters": parameters,
+                "result": result,
+            }
+        )
+        logger.info("Operation logged: %s - %s", operation, result)
+
+    def get_recent_operations(self, limit: int = 10) -> list[dict[str, Any]]:
+        return self.operations[-limit:]
+
+
+# Module singleton. Tests clear `operations` between cases.
+operation_logger = OperationLogger()
+
+
+def _safety_error(
+    operation: str,
+    message: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the standard safety-violation error dict and log it.
+
+    `params` is logged to `operation_logger` on the safety-violation entry.
+    When unset, falls back to `{"violation": message}` so the audit entry
+    is meaningfully shaped even when the caller doesn't thread its own
+    params (matches apple-mail's pattern).
+    """
     logger.warning("Safety violation in %s: %s", operation, message)
+    operation_logger.log_operation(
+        operation, params if params is not None else {"violation": message}, "safety_violation"
+    )
     return {
         "success": False,
         "error": message,
@@ -294,6 +357,11 @@ async def _confirm_destructive(
         identifier,
         description,
     )
+    operation_logger.log_operation(
+        operation,
+        {"entity_kind": entity_kind, "identifier": identifier, "action": action},
+        "cancelled",
+    )
     return {
         "success": False,
         "error": (
@@ -394,16 +462,16 @@ def check_rate_limit(
 ) -> dict[str, Any] | None:
     """Returns None if the call is allowed; a rate_limited error dict if not.
 
-    ``params`` is accepted for parity with apple-mail's signature; eventually
-    fed to the audit logger (#47) on deny. Currently unused.
+    ``params`` is logged to ``operation_logger`` on deny so the audit trail
+    records what the caller was trying to do when the gate fired. Tool-body
+    callers pass no params today; the empty dict still shapes the audit
+    entry consistently.
 
     Unknown operations pass through with a logger warning — the rate limiter
     fails open if a tool ships without a tier mapping, so a missed
     OPERATION_TIERS entry won't brick the server. Release-gate parity
-    checks should catch the missing mapping at PR time once #46 wires
-    this in.
+    checks catch the missing mapping at PR time.
     """
-    _ = params  # accepted for forward-compat with #47
     tier = OPERATION_TIERS.get(operation)
     if tier is None:
         logger.warning(
@@ -414,6 +482,7 @@ def check_rate_limit(
         return None
     if rate_limiter.check(tier):
         return None
+    operation_logger.log_operation(operation, params or {}, "rate_limited")
     max_calls, window = TIER_LIMITS[tier]
     return {
         "success": False,

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -17,6 +17,7 @@ from .security import (
     _is_test_mode_enabled,
     check_rate_limit,
     check_test_mode_safety,
+    operation_logger,
 )
 from .utils import detect_image_format
 
@@ -92,6 +93,7 @@ def check_authorization() -> dict[str, Any]:
     response: dict[str, Any] = {"success": True, "status": status}
     if status not in ("authorized", "limited"):
         response["remediation"] = _AUTH_REMEDIATION[status]
+    operation_logger.log_operation("check_authorization", {"status": status}, "success")
     return response
 
 
@@ -251,6 +253,11 @@ def list_contacts(offset: int = 0, limit: int = 50) -> dict[str, Any]:
         if auth_revoked is not None:
             return auth_revoked
 
+    operation_logger.log_operation(
+        "list_contacts",
+        {"offset": offset, "limit": effective_limit, "count": len(contacts)},
+        "success",
+    )
     return {
         "success": True,
         "contacts": contacts,
@@ -337,6 +344,11 @@ def get_contact(
             "error_type": "not_found",
         }
 
+    operation_logger.log_operation(
+        "get_contact",
+        {"identifier": identifier, "include_niche": include_niche},
+        "success",
+    )
     return {"success": True, "contact": contact}
 
 
@@ -432,6 +444,11 @@ def search_contacts(
         if auth_revoked is not None:
             return auth_revoked
 
+    operation_logger.log_operation(
+        "search_contacts",
+        {"search_field": field, "count": len(contacts)},
+        "success",
+    )
     return {
         "success": True,
         "contacts": contacts,
@@ -488,6 +505,9 @@ def list_containers() -> dict[str, Any]:
         auth_revoked = _verify_authorization_still_granted()
         if auth_revoked is not None:
             return auth_revoked
+    operation_logger.log_operation(
+        "list_containers", {"count": len(capped)}, "success"
+    )
     return {
         "success": True,
         "containers": capped,
@@ -536,6 +556,9 @@ def list_groups() -> dict[str, Any]:
         auth_revoked = _verify_authorization_still_granted()
         if auth_revoked is not None:
             return auth_revoked
+    operation_logger.log_operation(
+        "list_groups", {"count": len(capped)}, "success"
+    )
     return {
         "success": True,
         "groups": capped,
@@ -602,6 +625,11 @@ def get_contacts_in_group(identifier: str) -> dict[str, Any]:
         if auth_revoked is not None:
             return auth_revoked
 
+    operation_logger.log_operation(
+        "get_contacts_in_group",
+        {"group_identifier": identifier, "count": len(contacts)},
+        "success",
+    )
     return {
         "success": True,
         "group_identifier": identifier,
@@ -914,6 +942,23 @@ def create_contact(
     if auth_revoked is not None:
         return auth_revoked
 
+    operation_logger.log_operation(
+        "create_contact",
+        {
+            "container_identifier": container_identifier,
+            "group_identifier": group_identifier,
+            "phone_count": len(fields["phones"]),
+            "email_count": len(fields["emails"]),
+            "url_count": len(fields["urls"]),
+            "postal_count": len(fields["postal_addresses"]),
+            "has_birthday": fields["birthday"] is not None,
+            "date_count": len(fields["dates"]),
+            "social_count": len(fields["social_profiles"]),
+            "relation_count": len(fields["relations"]),
+            "im_count": len(fields["instant_messages"]),
+        },
+        "success",
+    )
     return {
         "success": True,
         "identifier": identifier,
@@ -1054,6 +1099,15 @@ def update_contact(
     if auth_revoked is not None:
         return auth_revoked
 
+    operation_logger.log_operation(
+        "update_contact",
+        {
+            "identifier": identifier,
+            "group_identifier": group_identifier,
+            "fields_updated": sorted(fields.keys()),
+        },
+        "success",
+    )
     return {"success": True, "identifier": identifier}
 
 
@@ -1147,6 +1201,11 @@ async def delete_contact(
     if auth_revoked is not None:
         return auth_revoked
 
+    operation_logger.log_operation(
+        "delete_contact",
+        {"identifier": identifier, "group_identifier": group_identifier},
+        "success",
+    )
     return {"success": True, "identifier": identifier}
 
 
@@ -1211,6 +1270,11 @@ def export_vcard(identifiers: list[str]) -> dict[str, Any]:
             "error_type": "unknown",
         }
 
+    operation_logger.log_operation(
+        "export_vcard",
+        {"identifier_count": len(identifiers), "vcard_size_bytes": len(vcard)},
+        "success",
+    )
     return {
         "success": True,
         "vcard": vcard,
@@ -1312,6 +1376,15 @@ def import_vcard(
     if auth_revoked is not None:
         return auth_revoked
 
+    operation_logger.log_operation(
+        "import_vcard",
+        {
+            "group_identifier": group_identifier,
+            "vcard_size_bytes": len(vcard_text),
+            "identifier_count": len(identifiers),
+        },
+        "success",
+    )
     return {
         "success": True,
         "identifiers": identifiers,
@@ -1371,6 +1444,11 @@ def read_note(identifier: str) -> dict[str, Any]:
             "error_type": "unknown",
         }
 
+    operation_logger.log_operation(
+        "read_note",
+        {"identifier": identifier, "note_length": len(note)},
+        "success",
+    )
     return {"success": True, "identifier": identifier, "note": note}
 
 
@@ -1437,6 +1515,15 @@ def write_note(
     if auth_revoked is not None:
         return auth_revoked
 
+    operation_logger.log_operation(
+        "write_note",
+        {
+            "identifier": identifier,
+            "group_identifier": group_identifier,
+            "note_length": len(note),
+        },
+        "success",
+    )
     return {"success": True, "identifier": identifier}
 
 
@@ -1494,6 +1581,11 @@ def read_photo(identifier: str) -> dict[str, Any]:
         }
 
     if not photo["available"]:
+        operation_logger.log_operation(
+            "read_photo",
+            {"identifier": identifier, "has_photo": False},
+            "success",
+        )
         return {
             "success": True,
             "identifier": identifier,
@@ -1503,11 +1595,22 @@ def read_photo(identifier: str) -> dict[str, Any]:
         }
 
     raw = photo["image_data"]
+    photo_format = detect_image_format(raw)
+    operation_logger.log_operation(
+        "read_photo",
+        {
+            "identifier": identifier,
+            "has_photo": True,
+            "size_bytes": len(raw),
+            "format": photo_format,
+        },
+        "success",
+    )
     return {
         "success": True,
         "identifier": identifier,
         "image_data": base64.b64encode(raw).decode("ascii"),
-        "format": detect_image_format(raw),
+        "format": photo_format,
         "size_bytes": len(raw),
     }
 
@@ -1597,6 +1700,16 @@ def write_photo(
     if auth_revoked is not None:
         return auth_revoked
 
+    operation_logger.log_operation(
+        "write_photo",
+        {
+            "identifier": identifier,
+            "group_identifier": group_identifier,
+            "size_bytes": len(decoded) if decoded is not None else 0,
+            "clearing": decoded is None,
+        },
+        "success",
+    )
     return {"success": True, "identifier": identifier}
 
 
@@ -1675,6 +1788,14 @@ def add_contact_to_group(
     if auth_revoked is not None:
         return auth_revoked
 
+    operation_logger.log_operation(
+        "add_contact_to_group",
+        {
+            "contact_identifier": contact_identifier,
+            "group_identifier": group_identifier,
+        },
+        "success",
+    )
     return {
         "success": True,
         "contact_identifier": contact_identifier,
@@ -1752,6 +1873,14 @@ def remove_contact_from_group(
     if auth_revoked is not None:
         return auth_revoked
 
+    operation_logger.log_operation(
+        "remove_contact_from_group",
+        {
+            "contact_identifier": contact_identifier,
+            "group_identifier": group_identifier,
+        },
+        "success",
+    )
     return {
         "success": True,
         "contact_identifier": contact_identifier,
@@ -1825,6 +1954,15 @@ def create_group(
     if auth_revoked is not None:
         return auth_revoked
 
+    operation_logger.log_operation(
+        "create_group",
+        {
+            "name_length": len(name),
+            "container_identifier": container_identifier,
+            "group_identifier": group_identifier,
+        },
+        "success",
+    )
     return {"success": True, "group": group}
 
 
@@ -1897,6 +2035,15 @@ def rename_group(
     if auth_revoked is not None:
         return auth_revoked
 
+    operation_logger.log_operation(
+        "rename_group",
+        {
+            "identifier": identifier,
+            "new_name_length": len(new_name),
+            "group_identifier": group_identifier,
+        },
+        "success",
+    )
     return {"success": True, "group": group}
 
 
@@ -1988,6 +2135,11 @@ async def delete_group(
     if auth_revoked is not None:
         return auth_revoked
 
+    operation_logger.log_operation(
+        "delete_group",
+        {"identifier": identifier, "group_identifier": group_identifier},
+        "success",
+    )
     return {"success": True, "identifier": identifier}
 
 

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -17,10 +17,12 @@ from apple_contacts_mcp.security import (
     DESTRUCTIVE_OPERATIONS,
     OPERATION_TIERS,
     TIER_LIMITS,
+    OperationLogger,
     RateLimiter,
     _get_test_group_identifiers,
     check_rate_limit,
     check_test_mode_safety,
+    operation_logger,
     rate_limiter,
     require_test_mode_for,
 )
@@ -356,9 +358,27 @@ class TestCheckRateLimit:
         assert "delete_contact" in result["error"]
         assert "destructives" in result["error"]
 
-    def test_params_is_accepted_but_unused(self, _fresh_rate_limiter: Any) -> None:
-        """The params kwarg matches apple-mail's signature for #47 forward-compat."""
-        assert check_rate_limit("list_contacts", params={"offset": 0}) is None
+    def test_params_logged_on_rate_limit_deny(
+        self, _fresh_rate_limiter: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On deny, the params dict is appended to the audit log."""
+        operation_logger.operations.clear()
+        fake_now = [0.0]
+        monkeypatch.setattr(
+            "apple_contacts_mcp.security.time.monotonic", lambda: fake_now[0]
+        )
+        for _ in range(TIER_LIMITS["destructives"][0]):
+            assert check_rate_limit("delete_contact", params={"k": "v"}) is None
+        # Allowed calls should not log.
+        assert operation_logger.operations == []
+        # Deny logs.
+        denied = check_rate_limit("delete_contact", params={"k": "v"})
+        assert denied is not None
+        assert len(operation_logger.operations) == 1
+        entry = operation_logger.operations[0]
+        assert entry["operation"] == "delete_contact"
+        assert entry["parameters"] == {"k": "v"}
+        assert entry["result"] == "rate_limited"
 
 
 class TestOperationTiersCoverage:
@@ -407,3 +427,277 @@ class TestOperationTiersCoverage:
             f"DESTRUCTIVE_OPERATIONS contains ops without a rate-limit "
             f"tier mapping: {sorted(unmapped)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #47: OperationLogger
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=False)
+def _fresh_operation_logger() -> Any:
+    """Clear the audit log between cases. Singleton state would otherwise
+    bleed across tests."""
+    operation_logger.operations.clear()
+    yield
+    operation_logger.operations.clear()
+
+
+class TestOperationLogger:
+    """Direct tests against the OperationLogger class."""
+
+    def test_log_operation_appends_entry(
+        self, _fresh_operation_logger: Any
+    ) -> None:
+        logger = OperationLogger()
+        logger.log_operation("test_op", {"k": "v"}, "success")
+        assert len(logger.operations) == 1
+        entry = logger.operations[0]
+        assert entry["operation"] == "test_op"
+        assert entry["parameters"] == {"k": "v"}
+        assert entry["result"] == "success"
+        # ISO-formatted timestamp string
+        assert isinstance(entry["timestamp"], str)
+        assert "T" in entry["timestamp"]
+
+    def test_default_result_is_success(
+        self, _fresh_operation_logger: Any
+    ) -> None:
+        logger = OperationLogger()
+        logger.log_operation("op", {})
+        assert logger.operations[0]["result"] == "success"
+
+    def test_get_recent_operations_returns_last_n_in_order(
+        self, _fresh_operation_logger: Any
+    ) -> None:
+        logger = OperationLogger()
+        for i in range(20):
+            logger.log_operation(f"op_{i}", {})
+        recent = logger.get_recent_operations(limit=5)
+        assert len(recent) == 5
+        assert [e["operation"] for e in recent] == [
+            "op_15",
+            "op_16",
+            "op_17",
+            "op_18",
+            "op_19",
+        ]
+
+    def test_get_recent_operations_default_limit_10(
+        self, _fresh_operation_logger: Any
+    ) -> None:
+        logger = OperationLogger()
+        for i in range(15):
+            logger.log_operation(f"op_{i}", {})
+        assert len(logger.get_recent_operations()) == 10
+
+    def test_singleton_is_shared(self, _fresh_operation_logger: Any) -> None:
+        """`operation_logger` is a module-level instance reused everywhere."""
+        operation_logger.log_operation("op_a", {"a": 1})
+        operation_logger.log_operation("op_b", {"b": 2})
+        assert len(operation_logger.operations) == 2
+
+
+class TestRateLimitDenyIsLogged:
+    """check_rate_limit auto-logs `rate_limited` on deny."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self, monkeypatch: pytest.MonkeyPatch) -> Any:
+        rate_limiter.reset()
+        operation_logger.operations.clear()
+        fake_now = [0.0]
+        monkeypatch.setattr(
+            "apple_contacts_mcp.security.time.monotonic", lambda: fake_now[0]
+        )
+        yield
+        operation_logger.operations.clear()
+        rate_limiter.reset()
+
+    def test_allow_path_does_not_log(self) -> None:
+        assert check_rate_limit("list_contacts") is None
+        assert operation_logger.operations == []
+
+    def test_deny_appends_rate_limited_entry(self) -> None:
+        for _ in range(TIER_LIMITS["destructives"][0]):
+            assert check_rate_limit("delete_contact") is None
+        # 6th call denies
+        denied = check_rate_limit("delete_contact")
+        assert denied is not None
+        assert len(operation_logger.operations) == 1
+        entry = operation_logger.operations[0]
+        assert entry["operation"] == "delete_contact"
+        assert entry["result"] == "rate_limited"
+
+    def test_unmapped_operation_does_not_log(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unknown ops pass through (fail open) and don't log a deny."""
+        with caplog.at_level("WARNING"):
+            assert check_rate_limit("never_heard_of_it") is None
+        assert operation_logger.operations == []
+
+
+class TestSafetyViolationIsLogged:
+    """check_test_mode_safety + require_test_mode_for deny paths log
+    `safety_violation` via _safety_error."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self) -> Any:
+        operation_logger.operations.clear()
+        _get_test_group_identifiers.cache_clear()
+        yield
+        operation_logger.operations.clear()
+
+    def test_missing_test_group_logs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.delenv("CONTACTS_TEST_GROUP", raising=False)
+        err = check_test_mode_safety("create_contact", group="X")
+        assert err is not None
+        assert err["error_type"] == "safety_violation"
+        assert len(operation_logger.operations) == 1
+        assert operation_logger.operations[0]["result"] == "safety_violation"
+        assert operation_logger.operations[0]["operation"] == "create_contact"
+
+    def test_group_mismatch_logs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
+        monkeypatch.setenv("CONTACTS_TEST_GROUP", "MCP-Test")
+        with patch(
+            "apple_contacts_mcp.security._get_test_group_identifiers",
+            return_value=frozenset({"MCP-Test"}),
+        ):
+            err = check_test_mode_safety(
+                "create_contact", group="WrongGroup"
+            )
+        assert err is not None
+        assert err["error_type"] == "safety_violation"
+        assert len(operation_logger.operations) == 1
+        assert operation_logger.operations[0]["result"] == "safety_violation"
+
+    def test_require_test_mode_for_outside_test_mode_logs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        err = require_test_mode_for("delete_contact")
+        assert err is not None
+        assert err["error_type"] == "safety_violation"
+        assert len(operation_logger.operations) == 1
+        assert operation_logger.operations[0]["operation"] == "delete_contact"
+        assert operation_logger.operations[0]["result"] == "safety_violation"
+
+    def test_allowed_safety_check_does_not_log(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
+        assert check_test_mode_safety("create_contact", group="X") is None
+        assert operation_logger.operations == []
+
+
+class TestConfirmDestructiveCancelledIsLogged:
+    """_confirm_destructive logs `cancelled` on user decline / cancel /
+    explicit-no, but not on accepted-yes."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self) -> Any:
+        operation_logger.operations.clear()
+        yield
+        operation_logger.operations.clear()
+
+    @pytest.mark.asyncio
+    async def test_declined_logs_cancelled(self) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        from fastmcp.server.elicitation import DeclinedElicitation
+
+        from apple_contacts_mcp.security import _confirm_destructive
+
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(return_value=DeclinedElicitation())
+        result = await _confirm_destructive(
+            ctx,
+            operation="delete_contact",
+            entity_kind="contact",
+            identifier="abc:ABPerson",
+            preview_lookup=lambda: {"id": "abc:ABPerson", "given_name": "X"},
+            describe=lambda p: "X",
+        )
+        assert result is not None
+        assert result["error_type"] == "user_declined"
+        assert len(operation_logger.operations) == 1
+        entry = operation_logger.operations[0]
+        assert entry["operation"] == "delete_contact"
+        assert entry["result"] == "cancelled"
+        assert entry["parameters"]["entity_kind"] == "contact"
+        assert entry["parameters"]["identifier"] == "abc:ABPerson"
+        assert entry["parameters"]["action"] == "declined"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_logs_cancelled(self) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        from fastmcp.server.elicitation import CancelledElicitation
+
+        from apple_contacts_mcp.security import _confirm_destructive
+
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(return_value=CancelledElicitation())
+        await _confirm_destructive(
+            ctx,
+            operation="delete_group",
+            entity_kind="group",
+            identifier="grp-1",
+            preview_lookup=lambda: {"id": "grp-1", "name": "X"},
+            describe=lambda p: "X",
+        )
+        assert len(operation_logger.operations) == 1
+        assert operation_logger.operations[0]["result"] == "cancelled"
+        assert operation_logger.operations[0]["parameters"]["action"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_accepted_yes_does_not_log(self) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        from fastmcp.server.elicitation import AcceptedElicitation
+
+        from apple_contacts_mcp.security import _confirm_destructive
+
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(
+            return_value=AcceptedElicitation(data="Yes, delete")
+        )
+        result = await _confirm_destructive(
+            ctx,
+            operation="delete_contact",
+            entity_kind="contact",
+            identifier="abc",
+            preview_lookup=lambda: {"id": "abc"},
+            describe=lambda p: "abc",
+        )
+        assert result is None
+        assert operation_logger.operations == []
+
+    @pytest.mark.asyncio
+    async def test_elicit_unsupported_logs_safety_violation(self) -> None:
+        """When the client raises on elicit, the function falls through to
+        _safety_error which logs safety_violation (not cancelled)."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from apple_contacts_mcp.security import _confirm_destructive
+
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(side_effect=RuntimeError("no elicit support"))
+        result = await _confirm_destructive(
+            ctx,
+            operation="delete_contact",
+            entity_kind="contact",
+            identifier="abc",
+            preview_lookup=lambda: {"id": "abc"},
+            describe=lambda p: "abc",
+        )
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+        assert len(operation_logger.operations) == 1
+        assert operation_logger.operations[0]["result"] == "safety_violation"

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -13,7 +13,11 @@ from apple_contacts_mcp.exceptions import (
     ContactsNotFoundError,
     ContactsTimeoutError,
 )
-from apple_contacts_mcp.security import _get_test_group_identifiers, rate_limiter
+from apple_contacts_mcp.security import (
+    _get_test_group_identifiers,
+    operation_logger,
+    rate_limiter,
+)
 from apple_contacts_mcp.server import (
     _verify_authorization_still_granted,
     add_contact_to_group,
@@ -41,11 +45,12 @@ from apple_contacts_mcp.server import (
 
 
 @pytest.fixture(autouse=True)
-def _reset_rate_limiter() -> None:
-    """Tools wire `check_rate_limit` (issue #46); the module-level
-    `rate_limiter` accumulates across tests. Reset between cases so
-    one tier's budget doesn't leak into the next test."""
+def _reset_security_singletons() -> None:
+    """Tools wire both `check_rate_limit` (#46) and `operation_logger` (#47);
+    both are module singletons that accumulate across tests. Reset between
+    cases so neither budget nor audit-log entries leak forward."""
     rate_limiter.reset()
+    operation_logger.operations.clear()
 
 
 class TestCheckAuthorization:
@@ -3009,3 +3014,121 @@ class TestRateLimitWiringPerTool:
         assert result["error_type"] == "rate_limited"
         mock_connector._run_cn_authorization_status.assert_not_called()
         mock_connector._run_cn_create_contact.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #47: operation_logger wiring drift guard
+# ---------------------------------------------------------------------------
+
+
+class TestOperationLoggerWiringPerTool:
+    """Every @mcp.tool() must call operation_logger.log_operation with its
+    own name on the success path. Mirrors #46's rate-limit drift guard.
+
+    Two checks:
+    1. Source-level: scan server.py and assert each tool body contains
+       `operation_logger.log_operation("<tool>"`.
+    2. Runtime: pick one tool per category (read / write / async-delete)
+       and verify the success path appends a single "success" entry.
+    """
+
+    def test_every_tool_calls_log_operation_with_own_name(self) -> None:
+        import re
+        from pathlib import Path
+
+        server_src = (
+            Path(__file__).resolve().parents[2]
+            / "src"
+            / "apple_contacts_mcp"
+            / "server.py"
+        ).read_text()
+        tool_decl = re.compile(
+            r"@mcp\.tool\(\)\s+(?:async\s+)?def\s+(\w+)\s*\([^)]*\)",
+            re.MULTILINE,
+        )
+        matches = list(tool_decl.finditer(server_src))
+        missing: list[str] = []
+        for i, m in enumerate(matches):
+            tool_name = m.group(1)
+            body_start = m.end()
+            body_end = matches[i + 1].start() if i + 1 < len(matches) else len(
+                server_src
+            )
+            body = server_src[body_start:body_end]
+            log_call = re.compile(
+                rf'operation_logger\.log_operation\(\s*"{re.escape(tool_name)}"',
+                re.DOTALL,
+            )
+            if not log_call.search(body):
+                missing.append(tool_name)
+        assert not missing, (
+            f"tools missing operation_logger.log_operation call (or with "
+            f"mismatched op name): {missing}"
+        )
+
+    def test_list_contacts_success_logs_one_success_entry(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_enumerate_contacts.return_value = [
+                {"id": "abc", "given_name": "A"}
+            ]
+            result = list_contacts()
+        assert result["success"] is True
+        assert len(operation_logger.operations) == 1
+        entry = operation_logger.operations[0]
+        assert entry["operation"] == "list_contacts"
+        assert entry["result"] == "success"
+        assert entry["parameters"]["count"] == 1
+
+    def test_create_contact_success_logs_one_success_entry(self) -> None:
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_create_contact.return_value = "new-id"
+            result = create_contact(given_name="Alice")
+        assert result["success"] is True
+        assert len(operation_logger.operations) == 1
+        entry = operation_logger.operations[0]
+        assert entry["operation"] == "create_contact"
+        assert entry["result"] == "success"
+        # PII curation: name fields not logged.
+        assert "given_name" not in entry["parameters"]
+        assert "family_name" not in entry["parameters"]
+        assert entry["parameters"]["phone_count"] == 0
+        assert entry["parameters"]["email_count"] == 0
+
+    async def test_delete_contact_success_logs_one_success_entry(
+        self,
+    ) -> None:
+        from fastmcp.server.elicitation import AcceptedElicitation
+
+        ctx = MagicMock()
+        ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data="Yes, delete"))
+        with patch("apple_contacts_mcp.server.connector") as mock_connector:
+            mock_connector._run_cn_authorization_status.return_value = "authorized"
+            mock_connector._run_cn_unified_contact.return_value = {
+                "id": "abc",
+                "given_name": "A",
+            }
+            mock_connector._run_cn_delete_contact.return_value = None
+            result = await delete_contact(ctx, identifier="abc")
+        assert result["success"] is True
+        assert len(operation_logger.operations) == 1
+        entry = operation_logger.operations[0]
+        assert entry["operation"] == "delete_contact"
+        assert entry["result"] == "success"
+        assert entry["parameters"]["identifier"] == "abc"
+
+    def test_rate_limited_call_logs_rate_limited_not_success(self) -> None:
+        """Belt-and-suspenders: rate-limit gate fires before the tool body,
+        so the success-path log_operation never runs."""
+        from apple_contacts_mcp.security import TIER_LIMITS
+
+        max_calls, _ = TIER_LIMITS["cheap_reads"]
+        for _ in range(max_calls):
+            assert rate_limiter.check("cheap_reads") is True
+        with patch("apple_contacts_mcp.server.connector"):
+            result = list_contacts()
+        assert result["error_type"] == "rate_limited"
+        # Exactly one entry — the rate-limit deny. No success entry.
+        results = [e["result"] for e in operation_logger.operations]
+        assert results == ["rate_limited"]


### PR DESCRIPTION
## Summary

Builds the `OperationLogger` audit-log primitive (analogous to apple-mail-mcp's `operation_logger`) and wires it into every `@mcp.tool()` invocation. Append-only in-memory record with shape `{timestamp, operation, parameters, result}`. Four `result` values:

- `success` — emitted by the tool body before each success return
- `rate_limited` — emitted by `check_rate_limit` on deny
- `safety_violation` — emitted by `_safety_error` (covers `check_test_mode_safety`, `require_test_mode_for`, and the elicit-unsupported branch of `_confirm_destructive`)
- `cancelled` — emitted by `_confirm_destructive` on user decline / cancel / explicit-no

Centralizing the deny paths in the three security primitives keeps tool bodies single-purpose; they only emit `success`.

Per-tool params are curated to exclude PII: identifiers, container/group IDs, counts, lengths, booleans, and sorted field-name lists. Actual name/email/phone/URL/note/image content is never persisted. `read_photo` logs at two distinct sites (one per success branch).

New drift-guard test mirrors #46's rate-limit invariant and fails CI if a new tool ships without an audit-log call. The autouse reset fixture in `test_server.py` now clears both `rate_limiter` and `operation_logger` between cases.

The MCP_PLAYBOOK already documented this contract (line 386: "OperationLogger singleton tracks all tool operations") — this PR makes that claim truthful.

## Test plan

- [x] 537 unit tests pass (up 16 from main: +5 OperationLogger direct, +3 rate-limit deny, +4 safety-violation, +4 confirm-cancel, +5 server wiring, -1 forward-compat replaced with logger-deny variant)
- [x] Coverage 95.70% (above 95% gate)
- [x] ruff clean
- [x] check_complexity.sh — all functions within CC ≤ 20 threshold (create_contact stayed at CC=16 by reusing the existing `fields` dict for counts)
- [x] check_client_server_parity.sh — no new connector methods
- [x] Pre-push hook (ruff + tests) ran clean on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)