### PR TITLE
fix: branch-protection required-check context name

### DIFF
--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -47,7 +47,7 @@ Set branch protection on `main` once CI is green:
 ./scripts/configure_branch_protection.sh
 ```
 
-Captures the required `Tests / unit-tests` check, PR-only merges, linear
+Captures the required `unit-tests` check, PR-only merges, linear
 history, `enforce_admins`, and bans force-pushes and deletions. Idempotent
 — re-run to surface drift or reapply after an accidental settings change.
 The exact PUT payload is in the script for auditability (#32).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `scripts/configure_branch_protection.sh` listed the required status check as `"Tests / unit-tests"` (workflow-name + job-id form). GitHub Actions actually reports the check-run name as just `"unit-tests"` (the job id from `.github/workflows/test.yml`), so the mismatch left PRs in `mergeStateStatus=BLOCKED` because no incoming status matched the required context. Fix: protection now requires `"unit-tests"`. BOOTSTRAP.md updated to match. The live `main` protection was patched directly via `gh api` ahead of this PR so PR #88 could merge through the normal flow; this script change keeps re-runs idempotent.
+
 ### Added
 
 - `tests/integration/test_modification_dates.py` — durability regression test for the undocumented `CNContact` runtime selectors `creationDate` and `modificationDate`. Fetches a freshly-created contact via `unifiedContactWithIdentifier_keysToFetch_error_` with the selectors as string key paths, calls each selector, and asserts the return is a non-None `datetime`. On failure, the diagnostic points to the AppleScript fallback (`creation date of person`, `modification date of person`) per SKILL.md §2. Closes gap-analysis Q2; the question is now empirically gated rather than open (#33).

--- a/scripts/configure_branch_protection.sh
+++ b/scripts/configure_branch_protection.sh
@@ -6,8 +6,11 @@
 # reapply after an accidental settings change.
 #
 # Settings applied:
-#   - Required status checks: "Tests / unit-tests" (strict: branch must
-#     be up to date with the base before merge).
+#   - Required status checks: "unit-tests" (strict: branch must be up to
+#     date with the base before merge). Context name is the job-id from
+#     .github/workflows/test.yml, NOT the "<workflow> / <job>" form GitHub
+#     sometimes shows in the UI — the GraphQL CheckRun "name" is the
+#     authoritative match.
 #   - PR required (no direct pushes); zero reviews required (solo repo —
 #     GitHub prohibits self-approval, so requiring reviews would block
 #     self-merges).
@@ -34,7 +37,7 @@ PAYLOAD=$(cat <<'JSON'
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["Tests / unit-tests"]
+    "contexts": ["unit-tests"]
   },
   "enforce_admins": true,
   "required_pull_request_reviews": null,


### PR DESCRIPTION
## Summary

`scripts/configure_branch_protection.sh` (shipped in #32) listed the required status check as `"Tests / unit-tests"`. GitHub Actions actually reports the check-run as just `"unit-tests"` (the job id from `.github/workflows/test.yml`), so the protection mismatch left PRs in `mergeStateStatus=BLOCKED` because no incoming status matched the required context.

PR #88 hit this on merge. I patched the live `main` protection via `gh api` directly (admin operations on protection settings aren't subject to `enforce_admins`) so #88 could merge through the standard flow. This PR fixes the script so re-running it doesn't reintroduce the bug.

BOOTSTRAP.md and CHANGELOG updated. No code changes outside infra.

## Test plan

- [x] Live protection on main is already correct (patched via gh api during the #88 merge)
- [x] Script now matches live state — re-running it is idempotent
- [x] BOOTSTRAP.md doc string matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)