### PR TITLE
infra: non-blocking PR-title close-keyword check (closes #83)

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,0 +1,70 @@
+name: PR Hygiene
+
+# Non-blocking check: flags `(#N)` references in the PR title that lack a
+# GitHub close keyword (`closes`, `fixes`, `resolves` + tenses) anywhere
+# in the title or body. Posts a comment on the PR; never fails CI.
+# Issue #83.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    branches: [main]
+
+jobs:
+  close-keyword-check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check close keywords
+        id: check
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          python3 scripts/check_pr_close_keywords.py > comment.md
+          if [ -s comment.md ]; then
+            echo "has_message=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_message=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Find existing bot comment
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          ID=$(gh api "repos/${{ github.repository }}/issues/$PR/comments" \
+              --jq '.[] | select(.body | contains("<!-- pr-close-keyword-check -->")) | .id' \
+              | head -n 1)
+          echo "comment_id=$ID" >> "$GITHUB_OUTPUT"
+
+      - name: Post or edit comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          ID="${{ steps.find.outputs.comment_id }}"
+          HAS_MSG="${{ steps.check.outputs.has_message }}"
+          if [ "$HAS_MSG" = "true" ]; then
+            BODY=$(cat comment.md)
+          else
+            # No gap → if a stale bot comment exists, update it to "resolved"
+            # so the maintainer sees the fix took effect; otherwise no-op.
+            if [ -z "$ID" ]; then
+              echo "No gap and no existing comment; nothing to do."
+              exit 0
+            fi
+            BODY=$'> [!TIP]\n> All `(#N)` references in the title now have close keywords. The referenced issue(s) will auto-close on merge.\n>\n> <!-- pr-close-keyword-check -->'
+          fi
+          if [ -n "$ID" ]; then
+            echo "Editing existing bot comment $ID"
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$ID" \
+              -f body="$BODY" >/dev/null
+          else
+            echo "Creating new bot comment"
+            gh pr comment "$PR" --body "$BODY"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `.github/workflows/pr-hygiene.yml` + `scripts/check_pr_close_keywords.py` — non-blocking check that posts a PR comment when the title references an issue via `(#N)` but neither the title nor body contains a close keyword (`closes`, `fixes`, `resolves`, all tenses, case-insensitive). The comment uses an HTML-comment marker for find-and-edit on subsequent title edits (no spam). When the gap is closed, the comment auto-updates to a "resolved" confirmation. Runs on `pull_request` `opened`/`edited`/`synchronize` events. CI never fails. Prevents the silent miss-and-close-by-hand seen on PR #82 (#83).
+
 ### Fixed
 
 - `scripts/configure_branch_protection.sh` listed the required status check as `"Tests / unit-tests"` (workflow-name + job-id form). GitHub Actions actually reports the check-run name as just `"unit-tests"` (the job id from `.github/workflows/test.yml`), so the mismatch left PRs in `mergeStateStatus=BLOCKED` because no incoming status matched the required context. Fix: protection now requires `"unit-tests"`. BOOTSTRAP.md updated to match. The live `main` protection was patched directly via `gh api` ahead of this PR so PR #88 could merge through the normal flow; this script change keeps re-runs idempotent.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ make test-integration  # Real Contacts.app tests
    - **Bug fixes:** include a regression test that fails before your fix and passes after.
    - **AppleScript changes:** an integration test under `tests/integration/`.
 3. Update `docs/reference/TOOLS.md` if you added/changed a tool
-4. PR description references the issue (`Closes #N`)
+4. PR description references the issue (`Closes #N`). The `pr-hygiene` workflow posts a non-blocking comment if a `(#N)` reference in the PR title has no close keyword in the title or body — fix it before merge so the issue auto-closes.
 
 ## Coding Standards
 

--- a/scripts/check_pr_close_keywords.py
+++ b/scripts/check_pr_close_keywords.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Parse a PR title + body and report `(#N)` references in the title that
+lack a corresponding GitHub close keyword (`closes`, `fixes`, `resolves`,
+case-insensitive, all tenses).
+
+Output:
+  - If any references are unmatched: print a Markdown comment-body to
+    stdout that the GitHub Action can post on the PR. Exit 0.
+  - Otherwise: no output. Exit 0.
+
+Exit code is always 0; the workflow uses presence-of-stdout as the
+signal, so this check never fails CI (issue #83 — non-blocking by
+design).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+# All GitHub close-keyword tenses, case-insensitive. See:
+# https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
+CLOSE_KEYWORD_PATTERN = re.compile(
+    r"(?i)\b(close[ds]?|fix(?:e[ds])?|resolve[ds]?)\s+#(\d+)"
+)
+
+# Issue references in the title we want to check, e.g. `feat: foo (#35)`.
+TITLE_REF_PATTERN = re.compile(r"\(#(\d+)\)")
+
+MARKER = "<!-- pr-close-keyword-check -->"
+
+
+def find_unmatched_refs(title: str, body: str) -> list[str]:
+    """Return the sorted list of issue numbers referenced in the title
+    via `(#N)` that don't have a close keyword in title OR body."""
+    title_refs = set(TITLE_REF_PATTERN.findall(title))
+    if not title_refs:
+        return []
+
+    combined = f"{title}\n{body}"
+    closed = {n for _kw, n in CLOSE_KEYWORD_PATTERN.findall(combined)}
+
+    unmatched = title_refs - closed
+    return sorted(unmatched, key=int)
+
+
+def build_comment(unmatched: list[str]) -> str:
+    """Render the PR comment body for the given unmatched refs."""
+    if len(unmatched) == 1:
+        n = unmatched[0]
+        ref_phrase = f"issue **#{n}**"
+        fix_phrase = f"add `closes #{n}` to the PR title or body"
+    else:
+        ref_phrase = "issues " + ", ".join(f"**#{n}**" for n in unmatched)
+        fix_phrase = (
+            "add a close keyword (e.g. `closes #N`) for each in the PR "
+            "title or body"
+        )
+
+    return (
+        f"> [!NOTE]\n"
+        f"> This PR's title references {ref_phrase} but no close keyword "
+        f"(`closes`, `fixes`, `resolves`) was found in the title or body. "
+        f"GitHub will not auto-close on merge.\n"
+        f">\n"
+        f"> To auto-close: {fix_phrase}. To leave open: ignore this comment.\n"
+        f">\n"
+        f"> {MARKER}\n"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--title",
+        default=os.environ.get("PR_TITLE", ""),
+        help="PR title (defaults to $PR_TITLE)",
+    )
+    parser.add_argument(
+        "--body",
+        default=os.environ.get("PR_BODY", ""),
+        help="PR body (defaults to $PR_BODY)",
+    )
+    args = parser.parse_args()
+
+    unmatched = find_unmatched_refs(args.title, args.body or "")
+    if unmatched:
+        sys.stdout.write(build_comment(unmatched))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_pr_close_keywords.py
+++ b/tests/unit/test_pr_close_keywords.py
@@ -1,0 +1,107 @@
+"""Tests for scripts/check_pr_close_keywords.py — the non-blocking PR
+title close-keyword check (issue #83).
+
+The script's contract:
+  - Exit code is always 0 (non-blocking).
+  - If `(#N)` references in the title lack any close keyword in title
+    or body, stdout contains the Markdown comment-body for the workflow
+    to post.
+  - Otherwise stdout is empty.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check_pr_close_keywords.py"
+
+
+def _run(title: str, body: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(SCRIPT), "--title", title, "--body", body],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+@pytest.mark.parametrize(
+    "title, body, description",
+    [
+        ("feat: foo (closes #35)", "", "title has close keyword"),
+        ("feat: foo (#35)", "Closes #35", "body has close keyword (capitalized)"),
+        ("feat: foo (closes #35) (fixes #36)", "", "both refs have inline keywords"),
+        ("feat: foo (resolves #35)", "", "resolves keyword"),
+        ("feat: foo (FIXES #35)", "", "case-insensitive keyword"),
+        ("feat: foo (#35)", "fix #35", "single-tense `fix` in body"),
+        ("feat: foo (#35)", "Closed #35 yesterday", "past-tense `closed` in body"),
+        ("feat: no refs at all", "", "no `(#N)` to flag"),
+        ("just a regular commit message", "with no refs", "neither title nor body has refs"),
+    ],
+)
+def test_clean_cases_produce_no_output(
+    title: str, body: str, description: str
+) -> None:
+    result = _run(title, body)
+    assert result.returncode == 0, f"{description}: non-zero exit {result.returncode}"
+    assert result.stdout == "", (
+        f"{description}: expected empty stdout, got:\n{result.stdout}"
+    )
+
+
+def test_unmatched_single_ref_is_flagged() -> None:
+    result = _run("feat: foo (#35)", "")
+    assert result.returncode == 0
+    assert "#35" in result.stdout
+    assert "no close keyword" in result.stdout
+    assert "<!-- pr-close-keyword-check -->" in result.stdout
+
+
+def test_unmatched_multi_ref_is_flagged_with_unmatched_only() -> None:
+    """When title has (#35) and (#36) and body closes #35, only #36 should
+    be flagged."""
+    result = _run("feat: foo (#35) (#36)", "closes #35")
+    assert result.returncode == 0
+    # #36 should appear as unmatched
+    assert "**#36**" in result.stdout
+    # #35 should NOT be flagged as unmatched
+    assert "**#35**" not in result.stdout
+
+
+def test_multiple_unmatched_refs_listed() -> None:
+    result = _run("feat: foo (#35) (#36) (#37)", "")
+    assert result.returncode == 0
+    for n in ("35", "36", "37"):
+        assert f"**#{n}**" in result.stdout, f"missing #{n} in output"
+
+
+def test_exit_code_always_zero_non_blocking_contract() -> None:
+    """All paths (flagged, clean, no-refs) exit 0 — the workflow uses
+    presence of stdout as the signal, not the exit code."""
+    for title, body in [
+        ("feat: foo (#999)", ""),  # flagged
+        ("feat: foo (closes #999)", ""),  # clean
+        ("feat: nothing", ""),  # no refs
+    ]:
+        result = _run(title, body)
+        assert result.returncode == 0, (
+            f"non-zero exit on {title!r}: {result.returncode}"
+        )
+
+
+def test_env_vars_work_as_fallback_for_flags() -> None:
+    """The script reads PR_TITLE/PR_BODY from env if --title/--body aren't
+    passed — matches the GitHub Actions invocation pattern."""
+    result = subprocess.run(
+        [str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={"PR_TITLE": "feat: foo (#42)", "PR_BODY": "", "PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0
+    assert "#42" in result.stdout


### PR DESCRIPTION
## Summary

Non-blocking PR-hygiene workflow that flags `(#N)` issue references in PR titles when neither title nor body has a GitHub close keyword (`closes`, `fixes`, `resolves` + tenses). Prevents the silent miss-and-close-by-hand pattern seen on PR #82.

**Components:**
- `scripts/check_pr_close_keywords.py` — stdlib-only parser, prints comment-body to stdout if any refs are unmatched. Always exits 0 (non-blocking contract).
- `.github/workflows/pr-hygiene.yml` — runs the script on `pull_request` `opened`/`edited`/`synchronize`; posts or edits a single bot comment via `gh api` (find-by-marker so no spam on title re-edits).
- When the gap is resolved (user adds the keyword), the same comment auto-updates to a "✓ resolved" tip.

**Edge cases handled:**
- All tenses (`close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`).
- Case-insensitive matching.
- Keyword in body counts even if title has bare `(#N)`.
- Mixed-refs: `(#35) (closes #36)` flags only #35.
- No refs in title: no comment posted, no work done.

**Bootstrap test:** This PR's own title uses `(closes #83)`, so when the workflow runs on its own first PR, the clean-path branch is exercised (no comment expected). If the workflow fails outright, the PR check surface will show it.

## Test plan

- [x] 14 fixture-driven unit tests in `tests/unit/test_pr_close_keywords.py` — parametrized clean cases + flagged cases + non-blocking-contract test + env-var fallback
- [x] Full suite: 568 tests pass (up 14 from main)
- [x] Manual smoke: `PR_TITLE='feat: foo (#35)' PR_BODY='' uv run python scripts/check_pr_close_keywords.py` prints comment, exit 0
- [x] Manual smoke: `PR_TITLE='feat: foo (closes #35)' …` prints nothing, exit 0
- [x] Ruff clean (incl. `scripts/`)
- [ ] (Live on this PR) Workflow runs successfully on `opened`; no comment posted because the title has `(closes #83)`
- [ ] (Post-merge, manual) Open a throwaway PR with `(#999999)` in title and no body keyword; expect bot comment within ~30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)