### PR TITLE
infra: enforce TOOLS.md <-> @mcp.tool() parity (closes #51)

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Client-server parity check
         run: ./scripts/check_client_server_parity.sh
 
+      - name: TOOLS.md parity check
+        run: ./scripts/check_tools_md_parity.sh
+
       - name: PyObjC safety check
         run: ./scripts/check_pyobjc_safety.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Client-server parity check
         run: ./scripts/check_client_server_parity.sh
 
+      - name: TOOLS.md parity check
+        run: ./scripts/check_tools_md_parity.sh
+
   test-summary:
     runs-on: ubuntu-latest
     needs: [unit-tests]

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ coverage:
 check-all: lint typecheck test complexity
 	@./scripts/check_version_sync.sh
 	@./scripts/check_client_server_parity.sh
+	@./scripts/check_tools_md_parity.sh
 	@echo ""
 	@echo "All checks passed."
 

--- a/scripts/check_tools_md_parity.sh
+++ b/scripts/check_tools_md_parity.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Verify every @mcp.tool() in server.py has a TOOLS.md entry, and vice versa.
+set -euo pipefail
+
+SERVER="src/apple_contacts_mcp/server.py"
+DOC="docs/reference/TOOLS.md"
+
+echo "Checking TOOLS.md <-> @mcp.tool() parity..."
+
+SERVER_TOOLS=$(grep -A1 '@mcp.tool' "$SERVER" 2>/dev/null \
+  | grep 'def ' \
+  | sed 's/.*def \([a-z_]*\)(.*/\1/' \
+  | sort || true)
+
+DOC_TOOLS=$(grep -E '^### [a-z_]+$' "$DOC" 2>/dev/null \
+  | sed 's/^### //' \
+  | sort || true)
+
+echo ""
+echo "Server tools (@mcp.tool):"
+echo "$SERVER_TOOLS" | sed 's/^/  /'
+echo ""
+echo "Documented tools (TOOLS.md):"
+echo "$DOC_TOOLS" | sed 's/^/  /'
+echo ""
+
+UNDOCUMENTED=$(comm -23 <(echo "$SERVER_TOOLS") <(echo "$DOC_TOOLS"))
+ORPHANED=$(comm -13 <(echo "$SERVER_TOOLS") <(echo "$DOC_TOOLS"))
+
+EXIT=0
+if [ -n "$UNDOCUMENTED" ]; then
+    echo "ERROR: @mcp.tool() functions missing from TOOLS.md:"
+    echo "$UNDOCUMENTED" | sed 's/^/  - /'
+    echo ""
+    EXIT=1
+fi
+if [ -n "$ORPHANED" ]; then
+    echo "ERROR: TOOLS.md entries with no matching @mcp.tool() in server.py:"
+    echo "$ORPHANED" | sed 's/^/  - /'
+    echo ""
+    EXIT=1
+fi
+
+if [ "$EXIT" -eq 0 ]; then
+    echo "TOOLS.md and @mcp.tool() registrations are in parity."
+fi
+exit $EXIT


### PR DESCRIPTION
## Summary
- New `scripts/check_tools_md_parity.sh` extracts `@mcp.tool()` names from `server.py` and `### <name>` headings from `docs/reference/TOOLS.md`, reports drift in either direction, and exits 1 on any mismatch.
- Mirrors `check_client_server_parity.sh` in style, but fatal — there's no "internal helper" carve-out for a user-facing doc.
- Wired into `make check-all` and both CI workflows (`test.yml`, `release-hygiene.yml`) that already run the sibling parity check.

Closes #51.

## Test plan
- [x] Positive case: `./scripts/check_tools_md_parity.sh` lists 21 tools on each side and exits 0.
- [x] Drift case A (undocumented tool): temporarily remove a `### <name>` heading → script prints `ERROR: @mcp.tool() functions missing from TOOLS.md` and exits 1.
- [x] Drift case B (orphaned doc): temporarily add `### nonexistent_tool` → script prints `ERROR: TOOLS.md entries with no matching @mcp.tool()` and exits 1.
- [x] `make check-all` passes end-to-end with the new step.
- [ ] CI: confirm new "TOOLS.md parity check" step appears green in the Tests workflow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)