### PR TITLE
release: v0.4.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,17 +1,22 @@
 # Apple Contacts MCP Server
 
-**Version:** v0.3.0
+**Version:** v0.4.0
 
-v0.3.0 ships the Phase 3 surface: containers (`list_containers` +
-`container_identifier` on `create_contact`), group CRUD (`create_group`,
-`rename_group`, `delete_group`), contact photo read/write with magic-byte
-format detection (`read_photo`, `write_photo`), and four niche labeled-value
-families (`dates`, `social_profiles`, `relations`, `instant_messages`) opt-in
-via `include_niche=True` on `get_contact`. Also closes gap-analysis Q8a
-(multi-container write round-trip empirically resolved) and lands the
-per-tool performance baselines suite. See
-[docs/reference/TOOLS.md](../docs/reference/TOOLS.md) for the API surface
-and [CHANGELOG.md](../CHANGELOG.md) for release notes.
+v0.4.0 is the infrastructure-hardening milestone. **No new tools** — the 21-tool
+surface from v0.3.0 is unchanged. Every `@mcp.tool()` now sits behind a uniform
+gate stack: input validation → sliding-window rate limit (`security.py`:
+`TIER_LIMITS`, `OPERATION_TIERS`, three tiers) → TCC entry check → operation →
+post-call TCC re-verification (catches mid-call revocation, #37) → audit log
+(`OperationLogger`, PII-curated params only, #47). Destructive ops
+(`delete_contact`, `delete_group`) gained FastMCP-elicitation confirmation UX
+(#36). Coverage gate raised 90% → 95% (#30). `scripts/check_pyobjc_safety.sh`
+statically enforces five PyObjC anti-patterns at PR time (#31), and
+`scripts/check_tools_md_parity.sh` enforces `@mcp.tool()` ↔ TOOLS.md parity
+(#51). Empirically resolved gap-analysis §3: macOS attributes Contacts TCC to
+the venv `python-3.11` interpreter, not to anything this repo ships — the
+`packaging/Info.plist` scaffold was shipped (#34) and reverted (#97) within the
+same release cycle. See [docs/reference/TOOLS.md](../docs/reference/TOOLS.md)
+for the API surface and [CHANGELOG.md](../CHANGELOG.md) for release notes.
 
 - `MCP_PLAYBOOK.md` is the authoritative project-agnostic reference.
 - `BOOTSTRAP.md` documents the initial repo setup (mostly historical now).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-28
+
+### Security
+
+- Bumped transitive deps `idna` 3.13 → 3.16 (CVE-2026-45409) and `starlette` 1.0.0 → 1.1.0 (PYSEC-2026-161) via `uv lock --upgrade-package`. Both pulled through `fastmcp`'s HTTP plumbing; neither is a direct project dep. Caught by `scripts/check_dependencies.sh` (`pip-audit`) during the v0.4.0 release-gate validation.
+
 ### Removed
 
 - **The `packaging/Info.plist` scaffold added under #34 (PR #92) is reverted.** Empirically verified: when Claude Desktop launches the venv shim, macOS attributes the Contacts TCC request to the **venv's `python-3.11` binary**, not to anything in this repo. The consent dialog reads "python-3.11 would like to search your contacts." Our `Info.plist` is never read on this launch path, and no bundling work would change that without breaking the MCP subprocess model. The `Info.plist` file, its `tests/unit/test_packaging.py` lock, and the `plutil -extract` version-sync block are all removed. README's `## Usage` section now documents the real attribution behavior so users aren't surprised by the python-3.11 dialog text. Gap-analysis §3 is rewritten to record the empirical finding instead of the open caveat. Closed v0.5.0 follow-ups #93–96 (bundling tool, signing, icon, localization) were filed on the same wrong premise and have already been closed as wrong-scope.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol server for Apple Contacts on macOS.
 
-**Version:** v0.3.0 — Phase 3 surface: containers, group CRUD, contact photos, niche fields. 21 tools total. See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for the API surface and [CHANGELOG.md](CHANGELOG.md) for release notes.
+**Version:** v0.4.0 — Infrastructure hardening: per-tool rate limiting, PII-curated audit log, post-call TCC re-verification, FastMCP-elicitation confirmation UX for destructive ops, coverage gate to 95%, PyObjC static safety analyzer, TOOLS.md ↔ `@mcp.tool()` parity check. Same 21 tools as v0.3.0 — no API surface changes. See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for the API surface and [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 ## Tools
 

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -2,7 +2,7 @@
 
 Reference for every MCP tool the apple-contacts-mcp server exposes.
 
-**Version:** v0.3.0 (tracks the package version)
+**Version:** v0.4.0 (tracks the package version)
 **Tools:** 21
 
 The source-of-truth for tool behavior is the docstrings in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-contacts-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for Apple Contacts integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_contacts_mcp/__init__.py
+++ b/src/apple_contacts_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Contacts MCP Server.
 A Model Context Protocol server for Apple Contacts integration.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/apple_contacts_mcp/security.py
+++ b/src/apple_contacts_mcp/security.py
@@ -351,11 +351,10 @@ async def _confirm_destructive(
         action = "cancelled"
 
     logger.info(
-        "%s %s by user (identifier=%s, preview=%s)",
+        "%s %s by user (identifier=%s, has_preview=True)",
         operation,
         action,
         identifier,
-        description,
     )
     operation_logger.log_operation(
         operation,

--- a/src/apple_contacts_mcp/server.py
+++ b/src/apple_contacts_mcp/server.py
@@ -604,6 +604,11 @@ def get_contacts_in_group(identifier: str) -> dict[str, Any]:
     try:
         group = connector._run_cn_fetch_group(identifier)
         if group is None:
+            # `None` could be genuinely-not-found OR mid-call TCC revocation.
+            # Issue #37.
+            auth_revoked = _verify_authorization_still_granted()
+            if auth_revoked is not None:
+                return auth_revoked
             return {
                 "success": False,
                 "error": f"No group found with identifier {identifier!r}",
@@ -1574,6 +1579,11 @@ def read_photo(identifier: str) -> dict[str, Any]:
         }
 
     if photo is None:
+        # `None` could be genuinely-not-found OR mid-call TCC revocation
+        # (unifiedContactWithIdentifier returns None for both). Issue #37.
+        auth_revoked = _verify_authorization_still_granted()
+        if auth_revoked is not None:
+            return auth_revoked
         return {
             "success": False,
             "error": f"Contact not found: {identifier!r}",

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "apple-contacts-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -837,11 +837,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -2129,15 +2129,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

**v0.4.0 — Infrastructure hardening.** No new tools; the 21-tool surface from v0.3.0 is unchanged in shape. Every `@mcp.tool()` now sits behind a uniform gate stack:

`input validation → check_rate_limit → _require_contacts_authorization → operation → _verify_authorization_still_granted (post-call, for destructives + suspicious reads) → operation_logger.log_operation`

## Headline changes (full detail in CHANGELOG)

- **Rate limiting (#35, #46)** — sliding-window limiter with 3 tiers (`cheap_reads` 60/min, `expensive_ops` 20/min, `destructives` 5/min). Refuses before TCC fires, so a rate-limited caller doesn't trigger an OS dialog.
- **Audit log (#47)** — `OperationLogger` records every tool call with PII-curated params (identifiers, counts, lengths, booleans — never names, emails, phones, notes, image bytes).
- **Post-call TCC re-verification (#37)** — catches mid-call revocation. Reads: triggered on suspicious empty/None results. Destructives: unconditional.
- **Confirmation UX (#36)** — `delete_contact` and `delete_group` use FastMCP `ctx.elicit()`; refuse gracefully on non-elicit clients, emit `user_declined` on decline/cancel.
- **Coverage 90% → 95% (#30)**, smoke test retired.
- **PyObjC static safety analyzer (#31)** — `scripts/check_pyobjc_safety.sh` enforces 5 anti-patterns at PR time.
- **Durability regression for CN runtime selectors (#33)** — `creationDate`/`modificationDate` locked by integration test.
- **TOOLS.md ↔ `@mcp.tool()` parity (#51)** — `scripts/check_tools_md_parity.sh` blocks doc drift in either direction.
- **Branch-protection captured in code (#32)**, **PR-title close-keyword nudge (#83)**.
- **Empirically resolved** the gap-analysis §3 bundling-note caveat: macOS attributes Contacts TCC to the venv `python-3.11`, not us. The `packaging/Info.plist` scaffold (#34) was shipped and reverted (#97) in the same cycle. Detail in gap-analysis §3.

## Release-gate fixes folded in

- Code-reviewer flagged **PII leak** in `security.py` system logger on elicitation decline/cancel — `description` (raw contact/group name) was emitted to stdout/stderr alongside the clean audit-log entry. Removed; logger now records `identifier` + action + `has_preview=True` sentinel only.
- Two **TCC re-check gaps** patched: `read_photo` and `get_contacts_in_group` were missing `_verify_authorization_still_granted()` on their `None` paths, so mid-call revocation could surface as spurious `not_found` instead of `authorization_denied`. Now consistent with `get_contact`.
- **Security bumps**: transitive deps `idna` 3.13 → 3.16 (CVE-2026-45409), `starlette` 1.0.0 → 1.1.0 (PYSEC-2026-161) via `uv lock`.

## v0.5.0 follow-ups already filed

- #98: consolidate `read_photo` / `write_photo` / `read_note` / `write_note` into `get_contact` / `update_contact` (breaking — anti-pattern adjudicated by the api-design skill's own decision tree).
- #99: update api-design skill (stale tool count + Contacts-themed examples + past-decisions section).
- #100: remove dead `require_test_mode_for` from `security.py` (minor cleanup, also surfaced by the release-gate review).

## Validation

- [x] Milestone v0.4.0: 0 open, 13 closed.
- [x] `make check-all` green (version sync, client-server parity, TOOLS.md parity, complexity, PyObjC safety, 568 unit tests).
- [x] Coverage 95.70% (gate 95%).
- [x] `pip-audit`: 0 known vulnerabilities.
- [x] Code review (`feature-dev:code-reviewer`) — all blockers + majors addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)