### PR TITLE
cleanup: remove dead require_test_mode_for from security.py (closes #100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`get_contact` opt-in flags `include_photo` and `include_note`.** Mirror the existing `include_niche` pattern. Photo data appears as `contact.photo = {image_data, format, size_bytes}` (or `null` when absent); note appears as `contact.note`. Both add measurable cost — `include_note` spawns an AppleScript subprocess; `include_photo` can return megabytes of base64.
 - **`update_contact` parameters `photo` and `note`.** Follow the same value-based clearing semantics as the existing string fields: `None` = don't touch, `""` = clear, value = set. Write order is CN fields → photo → note; failures after the first successful write surface as `partial_success`.
 
+### Removed
+
+- **Dead `require_test_mode_for` guard deleted from `security.py`.** This was the v0.1–v0.3 stopgap that refused destructive ops unless `CONTACTS_TEST_MODE=true`, pending a real confirmation UX. v0.4.0 shipped that UX via FastMCP elicitation (`_confirm_destructive`, #36), leaving `require_test_mode_for` unwired from every tool and kept alive only by its own unit tests. No functional change (closes #100).
+
 ## [0.4.0] - 2026-05-28
 
 ### Security

--- a/src/apple_contacts_mcp/security.py
+++ b/src/apple_contacts_mcp/security.py
@@ -154,26 +154,6 @@ def _get_test_group_identifiers(test_group_name: str) -> frozenset[str]:
     return frozenset(identifiers)
 
 
-def require_test_mode_for(operation: str) -> dict[str, Any] | None:
-    """Refuses an operation when CONTACTS_TEST_MODE is not 'true'.
-
-    Use for destructive ops that lack a confirmation UX — they are
-    only safe to expose in test mode until v0.4.0 ships the
-    confirmation flow (#24).
-
-    Returns None when test mode is enabled; otherwise a structured
-    safety_violation error dict.
-    """
-    if not _is_test_mode_enabled():
-        return _safety_error(
-            operation,
-            f"{operation} is only available with CONTACTS_TEST_MODE=true. "
-            f"The full destructive UX (with confirmation prompts) ships "
-            f"in v0.4.0 (#36).",
-        )
-    return None
-
-
 # ---------------------------------------------------------------------------
 # Operation audit log (#47)
 #

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -24,7 +24,6 @@ from apple_contacts_mcp.security import (
     check_test_mode_safety,
     operation_logger,
     rate_limiter,
-    require_test_mode_for,
 )
 
 
@@ -216,43 +215,6 @@ def _subprocess_failure() -> Any:
         raise FileNotFoundError("osascript not available in test env")
 
     return _boom
-
-
-# ---------------------------------------------------------------------------
-# require_test_mode_for
-# ---------------------------------------------------------------------------
-
-
-class TestRequireTestModeFor:
-    def test_env_unset_returns_safety_violation(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
-        result = require_test_mode_for("delete_contact")
-        assert result is not None
-        assert result["error_type"] == "safety_violation"
-        assert "delete_contact" in result["error"]
-        assert "v0.4.0" in result["error"]
-
-    def test_env_false_returns_safety_violation(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("CONTACTS_TEST_MODE", "false")
-        result = require_test_mode_for("delete_contact")
-        assert result is not None
-        assert result["error_type"] == "safety_violation"
-
-    def test_env_true_returns_none(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("CONTACTS_TEST_MODE", "true")
-        assert require_test_mode_for("delete_contact") is None
-
-    def test_env_TRUE_case_insensitive(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("CONTACTS_TEST_MODE", "TRUE")
-        assert require_test_mode_for("delete_contact") is None
 
 
 # ---------------------------------------------------------------------------
@@ -538,8 +500,8 @@ class TestRateLimitDenyIsLogged:
 
 
 class TestSafetyViolationIsLogged:
-    """check_test_mode_safety + require_test_mode_for deny paths log
-    `safety_violation` via _safety_error."""
+    """check_test_mode_safety deny paths log `safety_violation`
+    via _safety_error."""
 
     @pytest.fixture(autouse=True)
     def _isolate(self) -> Any:
@@ -575,17 +537,6 @@ class TestSafetyViolationIsLogged:
         assert err is not None
         assert err["error_type"] == "safety_violation"
         assert len(operation_logger.operations) == 1
-        assert operation_logger.operations[0]["result"] == "safety_violation"
-
-    def test_require_test_mode_for_outside_test_mode_logs(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv("CONTACTS_TEST_MODE", raising=False)
-        err = require_test_mode_for("delete_contact")
-        assert err is not None
-        assert err["error_type"] == "safety_violation"
-        assert len(operation_logger.operations) == 1
-        assert operation_logger.operations[0]["operation"] == "delete_contact"
         assert operation_logger.operations[0]["result"] == "safety_violation"
 
     def test_allowed_safety_check_does_not_log(


### PR DESCRIPTION
## Summary

Removes the dead `require_test_mode_for` guard from `security.py`. This was the v0.1–v0.3 stopgap that refused destructive ops unless `CONTACTS_TEST_MODE=true`, pending a real confirmation UX. v0.4.0 shipped that UX via FastMCP elicitation (`_confirm_destructive`, #36), leaving the guard unwired from every tool (server.py never imported it) and kept alive only by its own unit tests. Its docstring still framed `#36` / `v0.4.0` as *future* work — stale and misleading by v0.5.0.

Pure dead-code deletion, **no functional change**. The two helper dependencies (`_is_test_mode_enabled`, `_safety_error`) stay — they're still used by the active `check_test_mode_safety` and `_confirm_destructive` gates.

## Changes

- **`src/apple_contacts_mcp/security.py`** — delete the `require_test_mode_for` function.
- **`tests/unit/test_security.py`** — drop the import, the `TestRequireTestModeFor` class, and `test_require_test_mode_for_outside_test_mode_logs`; trim the now-stale `TestSafetyViolationIsLogged` docstring.
- **`CHANGELOG.md`** — `### Removed` note under `[Unreleased]`. Historical v0.3.0/v0.4.0 mentions left intact as accurate release record.

## Verification

- `rg require_test_mode_for src tests` → no matches.
- `make check-all` green: 546 passed, lint + types clean, 95% coverage gate held, TOOLS.md ↔ `@mcp.tool()` parity intact.

Closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)