### PR TITLE
docs: re-theme api-design skill to Contacts vocabulary (closes #99)

### DIFF
--- a/.claude/skills/api-design/SKILL.md
+++ b/.claude/skills/api-design/SKILL.md
@@ -5,23 +5,31 @@ description: Use BEFORE adding any new tool, parameter, or endpoint to the Apple
 
 # Apple Contacts MCP API Design
 
-The current API has 17 tools organized into 4 phases. Tool count should grow slowly and deliberately. Every new tool request must pass through the decision tree.
+The current API has 17 tools: the contact CRUD core (`list_contacts`, `get_contact`,
+`search_contacts`, `create_contact`, `update_contact`, `delete_contact`), the
+group/container surface (`list_groups`, `get_contacts_in_group`, `create_group`,
+`rename_group`, `delete_group`, `add_contact_to_group`, `remove_contact_from_group`,
+`list_containers`), vCard I/O (`export_vcard`, `import_vcard`), and `check_authorization`.
+Tool count should grow slowly and deliberately. Every new tool request must pass through
+the decision tree.
 
 ## Decision Tree: Use BEFORE Adding Any Tool
 
 ```
 Can an existing tool handle this with current parameters?  (70% of cases: YES)
-  |-- Searching with a new filter? -> Add parameter to search_messages()
-  |-- Reading with different format? -> Add parameter to get_message()
-  |-- Sending with new options? -> Extend send_email() or send_email_with_attachments()
+  |-- Searching with a known filter? -> use search_contacts(name/phone/email/organization)
+  |-- Reading a contact? -> get_contact(identifier)
+  |-- Editing a field? -> update_contact(identifier, <field>=...)
   |
 Can an existing tool handle this with a NEW parameter?  (20% of cases: YES)
-  |-- Example: search by date range -> add date_from, date_to to search_messages()
-  |-- Example: search flagged only -> add is_flagged to search_messages()
+  |-- Example: search by a new axis -> add a parameter to search_contacts()
+  |-- Example: return an extra field set -> add an include_* flag to get_contact()
+  |              (mirrors the real include_niche / include_photo / include_note flags)
+  |-- Example: write a new field -> add a parameter to update_contact()
   |
 Is this truly a distinct operation?  (10% of cases: MAYBE)
-  |-- Different Contacts.app object? (accounts, rules, smart mailboxes)
-  |-- Different action type? (not CRUD on messages/mailboxes)
+  |-- Different Contacts object? (containers, groups, group membership)
+  |-- Different action type? (not CRUD on a contact -- e.g. vCard import/export)
   |
 If NO to all three: You might need a new tool. This is rare.
 ```
@@ -30,60 +38,87 @@ If NO to all three: You might need a new tool. This is rare.
 
 ### Field-Specific Tools
 ```python
-# WRONG - creates tool sprawl
-mark_as_flagged(message_id)
-mark_as_unflagged(message_id)
-mark_as_junk(message_id)
+# WRONG - a field of a contact becomes its own tool (creates tool sprawl)
+read_photo(identifier)
+write_photo(identifier, image_data)
+read_note(identifier)
+write_note(identifier, note)
 
-# RIGHT - one tool with parameters
-flag_message(message_ids, flag_color)
-# or extend update capabilities into a general update_message() tool
+# RIGHT - the field is a parameter / flag on the contact's CRUD tools
+get_contact(identifier, include_photo=True)   # photo appears on the contact payload
+update_contact(identifier, photo="<base64>")  # "" clears, value sets
+get_contact(identifier, include_note=True)
+update_contact(identifier, note="...")
 ```
+This is exactly the consolidation made in #98 — see **Past Decisions** below.
 
 ### Specialized Search Tools
 ```python
 # WRONG - each filter becomes a tool
-get_unread_messages()
-get_flagged_messages()
-get_messages_from_sender()
+get_contacts_with_birthday_this_month()
+get_contacts_in_organization("Acme")
 
-# RIGHT - parameters on existing search
-search_messages(read_status="unread")
-search_messages(is_flagged=True)
-search_messages(sender_contains="user@example.com")
+# RIGHT - parameters on the existing search
+search_contacts(organization="Acme")
+# and if a birthday filter is ever needed, it is a NEW PARAMETER on search_contacts(),
+# e.g. search_contacts(birthday_window=(start, end)) -- not a new tool.
+# (That parameter does not ship today; it illustrates the right shape to add.)
 ```
 
 ### Formatted Text Returns
 ```python
 # WRONG - returns human-readable string
-def list_mailboxes():
-    return "Inbox (42 messages)\nSent (15 messages)"
+def list_groups():
+    return "Family (12 contacts)\nWork (34 contacts)"
 
 # RIGHT - returns structured data
-def list_mailboxes():
-    return {"success": True, "mailboxes": [{"name": "Inbox", "count": 42}, ...]}
+def list_groups():
+    return {"success": True, "groups": [{"name": "Family", "count": 12}, ...]}
 ```
 
 ## Response Format Rules
 
 1. **Always return `dict[str, Any]`** with `"success": bool`
-2. **Errors include `"error"` (message) and `"error_type"` (category)**
+2. **Errors include `"error"` (message) and `"error_type"` (category)** — e.g.
+   `validation_error`, `not_found`, `authorization_denied`, `partial_success`,
+   `safety_violation`, `user_declined`, `rate_limited`
 3. **Never return formatted text strings** — return structured data
-4. **Include context fields** — e.g., `"messages_found": 5` alongside the results
+4. **Include context fields** — e.g. `search_contacts` returns `"count"`,
+   `"search_field"`, and `"search_value"` alongside `"contacts"`; `create_contact`
+   returns nullable `"group_id"` / `"container_id"` so the shape is stable
 
 ## Tool Naming Convention
 
-- Verb + noun: `search_messages`, `get_message`, `send_email`
-- Plural when accepting lists: `delete_messages`, `mark_as_read`
-- Specific verb over generic: `flag_message` not `update_message_flag`
+- Verb + noun: `search_contacts`, `get_contact`, `create_contact`, `update_contact`
+- Specific verb over generic: `rename_group` not `update_group_name`
+- Most operations act on a single contact/group by `identifier` (singular). The batch
+  tools are the vCard pair — `export_vcard(identifiers)` takes a list, `import_vcard`
+  takes vCard text — so reach for a list parameter only when the operation is genuinely
+  set-oriented, not by default.
 
 ## Adding a New Tool Checklist
 
-1. Verify it doesn't fit in an existing tool (run through decision tree above)
-2. Write unit tests (mock AppleScript)
+1. Verify it doesn't fit in an existing tool (run through the decision tree above)
+2. Write unit tests (mock the `_run_cn_*` / `_run_applescript_*` boundaries in
+   `contacts_connector.py`)
 3. Write integration tests (real Contacts.app)
-4. Implement in `contacts_connector.py`
-5. Expose in `server.py`
-6. Run `./scripts/check_client_server_parity.sh`
-7. Update `docs/reference/TOOLS.md`
-8. Add blind eval scenarios if tool has non-obvious parameters
+4. Implement in `contacts_connector.py` — primary path is Contacts.framework via PyObjC;
+   the AppleScript fallback is only for the `note` field and creation/modification dates
+   (see CLAUDE.md Phase 0)
+5. Expose in `server.py` with `@mcp.tool()`
+6. Run `./scripts/check_tools_md_parity.sh` (`@mcp.tool()` ↔ TOOLS.md parity) and
+   `./scripts/check_pyobjc_safety.sh` (PyObjC anti-patterns)
+7. Update [`docs/reference/TOOLS.md`](../../../docs/reference/TOOLS.md)
+8. Add blind eval scenarios if the tool has non-obvious parameters
+
+## Past Decisions
+
+A breadcrumb log so an already-adjudicated anti-pattern isn't reintroduced.
+
+- **2026-05-30 — photo + note I/O consolidated (#98, PR #102).** Removed the four
+  field-specific tools `read_photo`, `write_photo`, `read_note`, `write_note` and folded
+  them into `get_contact(include_photo=…, include_note=…)` and
+  `update_contact(photo=…, note=…)`. They were textbook **Field-Specific Tool**
+  violations of the catalog above. Rule of thumb: **a field of an existing resource is a
+  parameter, not a tool.** Surface dropped 21 → 17. See
+  [`CHANGELOG.md`](../../../CHANGELOG.md).


### PR DESCRIPTION
## Summary

The `.claude/skills/api-design/SKILL.md` skill was adapted from apple-mail-mcp and never fully reworded — the decision tree routed to `search_messages` / `get_message` / `send_email`, the anti-pattern catalog flagged `mark_as_flagged` / `get_unread_messages` / `list_mailboxes`, and the response rules cited `"messages_found"`. None of that vocabulary fires for Contacts work, and the skill had no record of the #98 consolidation that its own anti-pattern catalog drove.

This rewrites the whole skill in the real 17-tool Contacts surface (per the user-approved "full re-theme" scope).

## Changes (doc-only, one file)

- **Decision tree** → `search_contacts` / `get_contact` (real `include_*` flags) / `update_contact`, with containers, groups, and vCard I/O as the "truly distinct operation" tier.
- **Anti-patterns** → *Field-Specific* now shows the real `read_photo`/`write_photo`/`read_note`/`write_note` (WRONG) folded into `get_contact(include_photo/note=…)` / `update_contact(photo/note=…)` (RIGHT); *Specialized Search* uses `search_contacts` with the birthday filter shown as the **shape to add** (explicitly noted as not-shipped, since `search_contacts` has no date filter today); *Formatted Text* uses `list_groups`.
- **Response rules / naming** → real context fields (`count`, `search_field`), the real `error_type` set, and the contact CRUD verbs; "plural for lists" corrected to reality (`export_vcard`/`import_vcard` are the batch pair, everything else is singular `identifier`).
- **Checklist** → real scripts (`check_tools_md_parity.sh`, `check_pyobjc_safety.sh`) and the CN-primary / AppleScript-fallback implementation path.
- **New "Past Decisions" section** → records the #98 photo+note consolidation (2026-05-30, PR #102) with the rule of thumb *"a field of an existing resource is a parameter, not a tool"* so the anti-pattern isn't reintroduced.

## Verification

- `rg -ni 'message|mailbox|send_email|flag_message|sender|junk|unread'` → only hit is the English word "message" describing the `error` field; no mail vocabulary remains.
- Every tool named in the skill exists in `server.py`'s `@mcp.tool()` set (diff is empty).
- Both added markdown links resolve (`../../../CHANGELOG.md`, `../../../docs/reference/TOOLS.md`).
- `make check-all` green.

Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)